### PR TITLE
fix(authentication): send security token email in user's locale

### DIFF
--- a/authentication/internal/pkg/application/application_test.go
+++ b/authentication/internal/pkg/application/application_test.go
@@ -68,7 +68,7 @@ func TestLoginBegin_NoPasskeys_SendsToken(t *testing.T) {
 		Return(extdomain.UserResponse{UserRef: userRef, Username: "alice", Email: "alice@example.com"}, nil).Times(1)
 	repo.EXPECT().GetPasskeys(gomock.Any(), userRef).Return(nil, nil).Times(1)
 	repo.EXPECT().CreateSecurityToken(gomock.Any(), userRef, gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	mail.EXPECT().SendSecurityToken(gomock.Any(), "alice@example.com", gomock.Any()).Return(nil).Times(1)
+	mail.EXPECT().SendSecurityToken(gomock.Any(), "alice@example.com", gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	app := New(repo, mail, nil, "secret")
 	resp, err := app.LoginBegin(context.Background(), domain.LoginBeginRequest{Email: "alice@example.com"})

--- a/authentication/internal/pkg/application/commands/login.go
+++ b/authentication/internal/pkg/application/commands/login.go
@@ -45,7 +45,7 @@ func (h LoginBeginHandler) LoginBegin(ctx context.Context, req domain.LoginBegin
 		if err = h.users.CreateSecurityToken(ctx, user.UserRef, token, expiresAt); err != nil {
 			return domain.LoginBeginResponse{}, err
 		}
-		if err = h.users.SendToken(ctx, user.Email, token); err != nil {
+		if err = h.users.SendToken(ctx, user.Email, token, req.Locale); err != nil {
 			return domain.LoginBeginResponse{}, err
 		}
 		return domain.LoginBeginResponse{NextStep: "verify_token"}, nil

--- a/authentication/internal/pkg/domain/user.go
+++ b/authentication/internal/pkg/domain/user.go
@@ -26,7 +26,8 @@ type CreateUserRequest struct {
 }
 
 type LoginBeginRequest struct {
-	Email string `json:"email" validate:"required,email" binding:"required" example:"john@example.com"`
+	Email  string `json:"email"  validate:"required,email" binding:"required" example:"john@example.com"`
+	Locale string `json:"locale" example:"sv"`
 }
 
 type LoginBeginResponse struct {
@@ -137,8 +138,8 @@ func (u *Users) VerifyAndConsumeToken(ctx context.Context, userRef uuid.UUID, to
 	return u.r.VerifyAndConsumeToken(ctx, userRef, token)
 }
 
-func (u *Users) SendToken(ctx context.Context, email, token string) error {
-	return u.m.SendSecurityToken(ctx, email, token)
+func (u *Users) SendToken(ctx context.Context, email, token, locale string) error {
+	return u.m.SendSecurityToken(ctx, email, token, locale)
 }
 
 func (u *Users) StoreWebAuthnSession(ctx context.Context, session WebAuthnSession) error {

--- a/authentication/internal/pkg/mail/brevo/brevo_client.go
+++ b/authentication/internal/pkg/mail/brevo/brevo_client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/config"
+	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/mail"
 )
 
 type BrevoClient struct {
@@ -21,16 +22,17 @@ func NewSender() *BrevoClient {
 	return &BrevoClient{client: brevolib.NewAPIClient(cfg)}
 }
 
-func (b BrevoClient) SendSecurityToken(ctx context.Context, toEmail string, token string) error {
+func (b BrevoClient) SendSecurityToken(ctx context.Context, toEmail string, token string, locale string) error {
+	subject, htmlContent, textContent := mail.SecurityTokenContent(token, locale)
 	mail := brevolib.SendSmtpEmail{
 		Sender: &brevolib.SendSmtpEmailSender{
 			Name:  "Bilcool",
 			Email: config.FromSenderEmail(),
 		},
 		To:          []brevolib.SendSmtpEmailTo{{Email: toEmail, Name: toEmail}},
-		Subject:     "Your BilCool security code",
-		HtmlContent: "Your security code is: <div><b>" + token + "</b><div>This code is valid for 10 minutes.",
-		TextContent: "Your security code is: " + token + "\n\nThis code is valid for 10 minutes.",
+		Subject:     subject,
+		HtmlContent: htmlContent,
+		TextContent: textContent,
 	}
 	_, response, err := b.client.TransactionalEmailsApi.SendTransacEmail(ctx, mail)
 	if err != nil {

--- a/authentication/internal/pkg/mail/brevo/brevo_client_test.go
+++ b/authentication/internal/pkg/mail/brevo/brevo_client_test.go
@@ -10,6 +10,6 @@ import (
 func TestSendingOkMessage(t *testing.T) {
 	t.Skipf("We don't want ting to send emails in tests and create spam")
 	client := NewSender()
-	err := client.SendSecurityToken(context.Background(), "arngrimurbjarnason@gmail.com", "123456")
+	err := client.SendSecurityToken(context.Background(), "arngrimurbjarnason@gmail.com", "123456", "")
 	require.NoError(t, err)
 }

--- a/authentication/internal/pkg/mail/content.go
+++ b/authentication/internal/pkg/mail/content.go
@@ -1,0 +1,19 @@
+package mail
+
+import "strings"
+
+// securityTokenContent returns subject, HTML body, and plain-text body for the
+// security-token email in the requested locale.
+// Supported locales: "sv", "sv-SE" (Swedish). All others default to English.
+func SecurityTokenContent(token, locale string) (subject, htmlContent, textContent string) {
+	if strings.HasPrefix(strings.ToLower(locale), "sv") {
+		subject = "Din BilCool säkerhetskod"
+		htmlContent = "Din säkerhetskod är: <div><b>" + token + "</b></div>Koden är giltig i 10 minuter."
+		textContent = "Din säkerhetskod är: " + token + "\n\nKoden är giltig i 10 minuter."
+		return
+	}
+	subject = "Your BilCool security code"
+	htmlContent = "Your security code is: <div><b>" + token + "</b></div>This code is valid for 10 minutes."
+	textContent = "Your security code is: " + token + "\n\nThis code is valid for 10 minutes."
+	return
+}

--- a/authentication/internal/pkg/mail/mail_sender.go
+++ b/authentication/internal/pkg/mail/mail_sender.go
@@ -4,5 +4,5 @@ import "context"
 
 //go:generate mockgen -source=mail_sender.go -destination=mail_sender_mock.go -package=mail
 type MailSender interface {
-	SendSecurityToken(ctx context.Context, toEmail string, token string) error
+	SendSecurityToken(ctx context.Context, toEmail string, token string, locale string) error
 }

--- a/authentication/internal/pkg/mail/ses/ses.go
+++ b/authentication/internal/pkg/mail/ses/ses.go
@@ -2,11 +2,12 @@ package ses
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsses "github.com/aws/aws-sdk-go-v2/service/sesv2"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+
+	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/mail"
 )
 
 type SesSender struct {
@@ -22,9 +23,8 @@ func NewSeSender(cfg aws.Config, fromEmail string) *SesSender {
 	}
 }
 
-func (s *SesSender) SendSecurityToken(ctx context.Context, email string, token string) error {
-	subject := "Your BilCool security code"
-	body := fmt.Sprintf("Your security code is: %s\n\nThis code is valid for 10 minutes.", token)
+func (s *SesSender) SendSecurityToken(ctx context.Context, email string, token string, locale string) error {
+	subject, _, body := mail.SecurityTokenContent(token, locale)
 	_, err := s.client.SendEmail(ctx, &awsses.SendEmailInput{
 		FromEmailAddress: aws.String(s.fromEmail),
 		Destination: &types.Destination{

--- a/authentication/internal/pkg/mail/ses/ses_test.go
+++ b/authentication/internal/pkg/mail/ses/ses_test.go
@@ -62,6 +62,7 @@ func (suite *sesTestSuite) TestSendMail() {
 		suite.T().Context(),
 		"arngrimurbjarnason@gmail.com",
 		"123456",
+		"",
 	)
 	suite.Require().NoError(err)
 	suite.T().Log(

--- a/authentication/internal/pkg/web/router.go
+++ b/authentication/internal/pkg/web/router.go
@@ -206,6 +206,9 @@ func (h *HttpRouter) loginBegin(c *gin.Context) {
 		NewError(c, http.StatusBadRequest, "invalid request body")
 		return
 	}
+	if req.Locale == "" {
+		req.Locale = c.GetHeader("Accept-Language")
+	}
 	resp, err := h.commands.LoginBegin(c.Request.Context(), req)
 	if err != nil {
 		log.Error().Err(err).Msg("login begin failed")


### PR DESCRIPTION
The security token email was always sent in English. This change makes
it locale-aware: English is the default, Swedish is used when the locale
starts with "sv" (e.g. "sv" or "sv-SE").

Locale is resolved from the optional `locale` field in the LoginBegin
JSON request body; if absent, it falls back to the `Accept-Language`
HTTP header. The locale flows through SendToken and SendSecurityToken
to both the Brevo and SES mail providers.

Closes #12

https://claude.ai/code/session_01KR9btUbGU84KE4JFarXsBk