### PR TITLE
feat(ui): add accent color selector for logged-in users

### DIFF
--- a/ui/bilcool-ui/src/components/layout/ColorSelector.tsx
+++ b/ui/bilcool-ui/src/components/layout/ColorSelector.tsx
@@ -1,0 +1,42 @@
+import { useTranslation } from 'react-i18next'
+import { useSettingsStore } from '../../stores/settingsStore'
+import type { AccentColor } from '../../stores/settingsStore'
+import { cn } from '../../lib/utils'
+
+const COLOR_OPTIONS: { value: AccentColor; hex: string }[] = [
+  { value: 'default', hex: '#71717a' },
+  { value: 'blue',    hex: '#3b82f6' },
+  { value: 'green',   hex: '#22c55e' },
+  { value: 'purple',  hex: '#a855f7' },
+  { value: 'rose',    hex: '#f43f5e' },
+]
+
+export default function ColorSelector() {
+  const { t } = useTranslation('common')
+  const accentColor = useSettingsStore((s) => s.accentColor)
+  const setAccentColor = useSettingsStore((s) => s.setAccentColor)
+
+  return (
+    <div
+      className="flex items-center gap-1.5 px-1"
+      role="radiogroup"
+      aria-label={t('color.label')}
+    >
+      {COLOR_OPTIONS.map(({ value, hex }) => (
+        <button
+          key={value}
+          role="radio"
+          aria-checked={accentColor === value}
+          aria-label={t(`color.${value}`)}
+          title={t(`color.${value}`)}
+          onClick={() => setAccentColor(value)}
+          className={cn(
+            'h-5 w-5 rounded-full ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+            accentColor === value ? 'ring-2 ring-ring ring-offset-2' : 'opacity-70 hover:opacity-100'
+          )}
+          style={{ backgroundColor: hex }}
+        />
+      ))}
+    </div>
+  )
+}

--- a/ui/bilcool-ui/src/components/layout/Sidebar.tsx
+++ b/ui/bilcool-ui/src/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../../hooks/useAuth'
 import { cn } from '../../lib/utils'
 import ThemeToggle from './ThemeToggle'
 import LanguageToggle from './LanguageToggle'
+import ColorSelector from './ColorSelector'
 
 interface SidebarProps {
   onNavigate: () => void
@@ -56,6 +57,7 @@ export default function Sidebar({ onNavigate }: SidebarProps) {
           <ThemeToggle />
           <LanguageToggle />
         </div>
+        <ColorSelector />
         <button
           onClick={logout}
           className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground min-h-[44px]"

--- a/ui/bilcool-ui/src/hooks/useThemeSync.ts
+++ b/ui/bilcool-ui/src/hooks/useThemeSync.ts
@@ -1,10 +1,14 @@
 import { useEffect } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
+import type { AccentColor } from '../stores/settingsStore'
 import i18n from '../i18n/index'
+
+const ACCENT_COLORS: AccentColor[] = ['blue', 'green', 'purple', 'rose']
 
 export function useThemeSync() {
   const theme = useSettingsStore((s) => s.theme)
   const language = useSettingsStore((s) => s.language)
+  const accentColor = useSettingsStore((s) => s.accentColor)
 
   useEffect(() => {
     const root = document.documentElement
@@ -36,4 +40,12 @@ export function useThemeSync() {
     i18n.changeLanguage(language)
     document.documentElement.setAttribute('lang', language)
   }, [language])
+
+  useEffect(() => {
+    const root = document.documentElement
+    ACCENT_COLORS.forEach((c) => root.classList.remove(`accent-${c}`))
+    if (accentColor !== 'default') {
+      root.classList.add(`accent-${accentColor}`)
+    }
+  }, [accentColor])
 }

--- a/ui/bilcool-ui/src/i18n/locales/en/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/common.json
@@ -8,6 +8,7 @@
     "sign_out": "Sign out"
   },
   "theme": { "light": "Light", "dark": "Dark", "system": "System" },
+  "color": { "label": "Accent color", "default": "Default", "blue": "Blue", "green": "Green", "purple": "Purple", "rose": "Rose" },
   "language": { "en": "English", "sv": "Swedish" },
   "auth": {
     "email_label": "Email address",

--- a/ui/bilcool-ui/src/i18n/locales/sv/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/common.json
@@ -8,6 +8,7 @@
     "sign_out": "Logga ut"
   },
   "theme": { "light": "Ljust", "dark": "Mörkt", "system": "System" },
+  "color": { "label": "Accentfärg", "default": "Standard", "blue": "Blå", "green": "Grön", "purple": "Lila", "rose": "Rosa" },
   "language": { "en": "Engelska", "sv": "Svenska" },
   "auth": {
     "email_label": "E-postadress",

--- a/ui/bilcool-ui/src/index.css
+++ b/ui/bilcool-ui/src/index.css
@@ -69,6 +69,51 @@
   }
 }
 
+/* Accent color palettes — applied via .accent-<color> on <html> */
+.accent-blue {
+  --primary: 221 83% 53%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 221 83% 53%;
+}
+.accent-blue.dark {
+  --primary: 217 91% 60%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 217 91% 60%;
+}
+
+.accent-green {
+  --primary: 142 71% 45%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 142 71% 45%;
+}
+.accent-green.dark {
+  --primary: 142 76% 36%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 142 76% 36%;
+}
+
+.accent-purple {
+  --primary: 262 83% 58%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 262 83% 58%;
+}
+.accent-purple.dark {
+  --primary: 263 70% 50%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 263 70% 50%;
+}
+
+.accent-rose {
+  --primary: 347 77% 50%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 347 77% 50%;
+}
+.accent-rose.dark {
+  --primary: 347 77% 50%;
+  --primary-foreground: 0 0% 98%;
+  --ring: 347 77% 50%;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/ui/bilcool-ui/src/stores/settingsStore.ts
+++ b/ui/bilcool-ui/src/stores/settingsStore.ts
@@ -1,11 +1,15 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+export type AccentColor = 'default' | 'blue' | 'green' | 'purple' | 'rose';
+
 interface SettingsState {
   theme: 'light' | 'dark' | 'system';
   language: 'en' | 'sv';
+  accentColor: AccentColor;
   setTheme: (t: 'light' | 'dark' | 'system') => void;
   setLanguage: (l: 'en' | 'sv') => void;
+  setAccentColor: (c: AccentColor) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -13,8 +17,10 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       theme: 'system',
       language: 'sv',
+      accentColor: 'default',
       setTheme: (theme) => set({ theme }),
       setLanguage: (language) => set({ language }),
+      setAccentColor: (accentColor) => set({ accentColor }),
     }),
     { name: 'bilcool_settings' }
   )


### PR DESCRIPTION
Implements issue #10. Logged-in users can now pick an accent color
(Default, Blue, Green, Purple, Rose) from a row of color swatches in
the sidebar. The selection is persisted to localStorage alongside the
existing theme and language preferences and applied to the document root
via CSS custom property overrides.

- settingsStore: adds `accentColor: AccentColor` field + `setAccentColor` action
- index.css: adds `.accent-{blue,green,purple,rose}` palette classes that
  override `--primary` and `--ring` for both light and dark modes
- useThemeSync: applies/removes the accent class on `<html>` reactively
- ColorSelector: new sidebar component with accessible radio-style swatches
- i18n: color label translations added for EN and SV locales

https://claude.ai/code/session_0171umDkTHQJ8ssTuhR1JfEq