### PR TITLE
Make UI sidebar foldable on desktop

### DIFF
--- a/ui/bilcool-ui/src/components/layout/AppShell.tsx
+++ b/ui/bilcool-ui/src/components/layout/AppShell.tsx
@@ -5,11 +5,16 @@ import Header from './Header'
 
 export default function AppShell() {
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
 
   return (
     <div className="flex min-h-svh bg-background">
-      <div className="hidden md:flex md:w-64 md:flex-shrink-0">
-        <Sidebar onNavigate={() => setDrawerOpen(false)} />
+      <div className={`hidden md:flex md:flex-shrink-0 transition-all duration-300 ${sidebarCollapsed ? 'md:w-16' : 'md:w-64'}`}>
+        <Sidebar
+          onNavigate={() => setDrawerOpen(false)}
+          collapsed={sidebarCollapsed}
+          onToggleCollapse={() => setSidebarCollapsed((c) => !c)}
+        />
       </div>
 
       {drawerOpen && (

--- a/ui/bilcool-ui/src/components/layout/Sidebar.tsx
+++ b/ui/bilcool-ui/src/components/layout/Sidebar.tsx
@@ -1,48 +1,63 @@
 import { NavLink } from 'react-router-dom'
-import { CalendarDays, ClipboardList, User, Users } from 'lucide-react'
+import { CalendarDays, ClipboardList, User, Users, ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAuthStore } from '../../stores/authStore'
 import { cn } from '../../lib/utils'
 
 interface SidebarProps {
   onNavigate: () => void
+  collapsed?: boolean
+  onToggleCollapse?: () => void
 }
 
-const navLinkClass = ({ isActive }: { isActive: boolean }) =>
-  cn(
-    'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors min-h-[44px]',
-    isActive
-      ? 'bg-accent text-accent-foreground'
-      : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
-  )
-
-export default function Sidebar({ onNavigate }: SidebarProps) {
+export default function Sidebar({ onNavigate, collapsed = false, onToggleCollapse }: SidebarProps) {
   const { t } = useTranslation('common')
   const role = useAuthStore((s) => s.role)
 
+  const navLinkClass = ({ isActive }: { isActive: boolean }) =>
+    cn(
+      'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors min-h-[44px]',
+      collapsed ? 'justify-center gap-0' : 'gap-3',
+      isActive
+        ? 'bg-accent text-accent-foreground'
+        : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
+    )
+
   return (
-    <div className="flex h-full flex-col border-r bg-background">
-      <div className="flex h-14 items-center border-b px-4">
-        <span className="text-lg font-semibold">{t('app_name')}</span>
+    <div className="flex h-full w-full flex-col border-r bg-background overflow-hidden">
+      <div className="flex h-14 items-center border-b px-3 gap-2">
+        {!collapsed && <span className="text-lg font-semibold flex-1 truncate">{t('app_name')}</span>}
+        {onToggleCollapse && (
+          <button
+            onClick={onToggleCollapse}
+            className={cn(
+              'flex items-center justify-center rounded-lg p-1.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors',
+              collapsed && 'w-full'
+            )}
+            aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {collapsed ? <ChevronRight className="h-4 w-4" /> : <ChevronLeft className="h-4 w-4" />}
+          </button>
+        )}
       </div>
 
-      <nav className="flex-1 space-y-1 p-3" aria-label="Main navigation">
-        <NavLink to="/" end className={navLinkClass} onClick={onNavigate}>
-          <CalendarDays className="h-4 w-4" aria-hidden="true" />
-          {t('nav.calendar')}
+      <nav className="flex-1 space-y-1 p-2" aria-label="Main navigation">
+        <NavLink to="/" end className={navLinkClass} onClick={onNavigate} title={collapsed ? t('nav.calendar') : undefined}>
+          <CalendarDays className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {!collapsed && t('nav.calendar')}
         </NavLink>
-        <NavLink to="/bookings" className={navLinkClass} onClick={onNavigate}>
-          <ClipboardList className="h-4 w-4" aria-hidden="true" />
-          {t('nav.bookings')}
+        <NavLink to="/bookings" className={navLinkClass} onClick={onNavigate} title={collapsed ? t('nav.bookings') : undefined}>
+          <ClipboardList className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {!collapsed && t('nav.bookings')}
         </NavLink>
-        <NavLink to="/profile" className={navLinkClass} onClick={onNavigate}>
-          <User className="h-4 w-4" aria-hidden="true" />
-          {t('nav.profile')}
+        <NavLink to="/profile" className={navLinkClass} onClick={onNavigate} title={collapsed ? t('nav.profile') : undefined}>
+          <User className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {!collapsed && t('nav.profile')}
         </NavLink>
         {role === 'admin' && (
-          <NavLink to="/admin/users" className={navLinkClass} onClick={onNavigate}>
-            <Users className="h-4 w-4" aria-hidden="true" />
-            {t('nav.admin_users')}
+          <NavLink to="/admin/users" className={navLinkClass} onClick={onNavigate} title={collapsed ? t('nav.admin_users') : undefined}>
+            <Users className="h-4 w-4 shrink-0" aria-hidden="true" />
+            {!collapsed && t('nav.admin_users')}
           </NavLink>
         )}
       </nav>


### PR DESCRIPTION
Adds a collapse/expand toggle button to the desktop sidebar. When collapsed, the sidebar shrinks to icon-only width (w-16) with tooltips on nav items; when expanded it returns to full width (w-64) with smooth CSS transition. Mobile drawer behavior is unchanged.

Closes #23