### PR TITLE
Add user booking color selection in settings

### DIFF
--- a/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
+++ b/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
@@ -15,6 +15,7 @@ import BookingStartEndDialog from '../bookings/BookingStartEndDialog'
 import { Button } from '../ui/button'
 import type { BookingResponse } from '../../types/api'
 import { snapToQuarterHour } from '../../utils/bookingUtils'
+import { getColorForUserRef } from '../../utils/bookingColors'
 import CalendarEvent from './CalendarEvent'
 
 type ViewType = 'dayGridMonth' | 'timeGridWeek' | 'timeGridDay'
@@ -29,6 +30,7 @@ interface CalendarViewProps {
 
 export default function CalendarView({ completedBookingMap }: CalendarViewProps) {
   const language = useSettingsStore((s) => s.language)
+  const bookingColor = useSettingsStore((s) => s.bookingColor)
   const userRef = useAuthStore((s) => s.userRef)
   const { data: bookings = [] } = useBookings()
 
@@ -61,7 +63,7 @@ export default function CalendarView({ completedBookingMap }: CalendarViewProps)
       title: username,
       start: b.start_date,
       end: b.end_date,
-      color: isOwn ? 'hsl(240, 5.9%, 10%)' : 'hsl(240, 3.8%, 46.1%)',
+      color: isOwn ? bookingColor : getColorForUserRef(b.user_ref, bookingColor),
       extendedProps: { booking: b, isOwn },
     }
   })

--- a/ui/bilcool-ui/src/components/layout/SettingsDialog.tsx
+++ b/ui/bilcool-ui/src/components/layout/SettingsDialog.tsx
@@ -9,9 +9,13 @@ import {
   DialogTrigger,
 } from '../ui/dialog'
 import ThemeToggle from './ThemeToggle'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { BOOKING_COLORS } from '../../utils/bookingColors'
 
 export default function SettingsDialog() {
   const { t } = useTranslation('common')
+  const bookingColor = useSettingsStore((s) => s.bookingColor)
+  const setBookingColor = useSettingsStore((s) => s.setBookingColor)
 
   return (
     <Dialog>
@@ -33,6 +37,24 @@ export default function SettingsDialog() {
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium">{t('settings.theme')}</span>
             <ThemeToggle />
+          </div>
+          <div className="flex flex-col gap-2">
+            <span className="text-sm font-medium">{t('settings.bookingColor')}</span>
+            <div className="flex gap-2 flex-wrap">
+              {BOOKING_COLORS.map((color) => (
+                <button
+                  key={color}
+                  onClick={() => setBookingColor(color)}
+                  className="w-8 h-8 rounded-full transition-all"
+                  style={{
+                    backgroundColor: color,
+                    outline: bookingColor === color ? `2px solid ${color}` : 'none',
+                    outlineOffset: '2px',
+                  }}
+                  aria-label={color}
+                />
+              ))}
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/ui/bilcool-ui/src/i18n/locales/en/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/common.json
@@ -8,7 +8,7 @@
     "sign_out": "Sign out",
     "settings": "Settings"
   },
-  "settings": { "theme": "Theme" },
+  "settings": { "theme": "Theme", "bookingColor": "Booking color" },
   "theme": { "light": "Light", "dark": "Dark", "system": "System" },
   "color": { "label": "Accent color", "default": "Default", "blue": "Blue", "green": "Green", "purple": "Purple", "rose": "Rose" },
   "language": { "en": "English", "sv": "Swedish" },

--- a/ui/bilcool-ui/src/i18n/locales/sv/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/common.json
@@ -8,7 +8,7 @@
     "sign_out": "Logga ut",
     "settings": "Inställningar"
   },
-  "settings": { "theme": "Tema" },
+  "settings": { "theme": "Tema", "bookingColor": "Bokningsfärg" },
   "theme": { "light": "Ljust", "dark": "Mörkt", "system": "System" },
   "color": { "label": "Accentfärg", "default": "Standard", "blue": "Blå", "green": "Grön", "purple": "Lila", "rose": "Rosa" },
   "language": { "en": "Engelska", "sv": "Svenska" },

--- a/ui/bilcool-ui/src/stores/settingsStore.ts
+++ b/ui/bilcool-ui/src/stores/settingsStore.ts
@@ -1,11 +1,14 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
+import { DEFAULT_BOOKING_COLOR } from '../utils/bookingColors';
 
 interface SettingsState {
   theme: 'light' | 'dark' | 'system';
   language: 'en' | 'sv';
+  bookingColor: string;
   setTheme: (t: 'light' | 'dark' | 'system') => void;
   setLanguage: (l: 'en' | 'sv') => void;
+  setBookingColor: (c: string) => void;
 }
 
 export const useSettingsStore = create<SettingsState>()(
@@ -13,8 +16,10 @@ export const useSettingsStore = create<SettingsState>()(
     (set) => ({
       theme: 'system',
       language: 'sv',
+      bookingColor: DEFAULT_BOOKING_COLOR,
       setTheme: (theme) => set({ theme }),
       setLanguage: (language) => set({ language }),
+      setBookingColor: (bookingColor) => set({ bookingColor }),
     }),
     { name: 'bilcool_settings' }
   )

--- a/ui/bilcool-ui/src/utils/bookingColors.ts
+++ b/ui/bilcool-ui/src/utils/bookingColors.ts
@@ -1,0 +1,27 @@
+export const BOOKING_COLORS = [
+  '#3b82f6',
+  '#22c55e',
+  '#a855f7',
+  '#f43f5e',
+  '#f97316',
+  '#14b8a6',
+  '#6366f1',
+  '#f59e0b',
+]
+
+export const DEFAULT_BOOKING_COLOR = BOOKING_COLORS[0]
+
+const otherUserColorMap = new Map<string, string>()
+
+export function getColorForUserRef(userRef: string, excludeColor: string): string {
+  if (otherUserColorMap.has(userRef)) {
+    return otherUserColorMap.get(userRef)!
+  }
+  const available = BOOKING_COLORS.filter((c) => c !== excludeColor)
+  const pool = available.length > 0 ? available : BOOKING_COLORS
+  const usedColors = new Set(otherUserColorMap.values())
+  const unused = pool.filter((c) => !usedColors.has(c))
+  const color = unused.length > 0 ? unused[0] : pool[otherUserColorMap.size % pool.length]
+  otherUserColorMap.set(userRef, color)
+  return color
+}


### PR DESCRIPTION
Users can now pick a color for their own bookings from a palette of 8 colors in the Settings dialog. Other users' bookings receive distinct randomized colors per session (stable, reusing if palette is exhausted). Color preference is persisted in localStorage via the settings store.