### PR TITLE
fix(#38): route finished bookings to journal service

### DIFF
--- a/journal/internal/pkg/persistance/postgres/events.go
+++ b/journal/internal/pkg/persistance/postgres/events.go
@@ -146,14 +146,23 @@ func (r EventRepository) handleBookingEnded(ctx context.Context, payload json.Ra
 	return err
 }
 
-func (r EventRepository) GetFinishedBookings(ctx context.Context) ([]FinishedBooking, error) {
+type FinishedBookingFilter struct {
+	Year    *int
+	Month   *int
+	UserRef *uuid.UUID
+}
+
+func (r EventRepository) GetFinishedBookings(ctx context.Context, f FinishedBookingFilter) ([]FinishedBooking, error) {
 	const query = `
 SELECT b.booking_ref, u.user_ref, b.start_date, b.end_date, b.distance_meters
 FROM booking_ended_events b
 INNER JOIN users u ON b.fk_user = u.id
+WHERE ($1::int IS NULL OR EXTRACT(YEAR  FROM b.start_date) = $1)
+  AND ($2::int IS NULL OR EXTRACT(MONTH FROM b.start_date) = $2)
+  AND ($3::uuid IS NULL OR u.user_ref = $3)
 ORDER BY b.start_date DESC`
 
-	rows, err := r.QueryContext(ctx, query)
+	rows, err := r.QueryContext(ctx, query, f.Year, f.Month, f.UserRef)
 	if err != nil {
 		return nil, err
 	}

--- a/journal/internal/pkg/web/router.go
+++ b/journal/internal/pkg/web/router.go
@@ -6,17 +6,19 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"github.com/arngrimur/bilcool_monolith/journal/internal/pkg/persistance/postgres"
 )
 
 type BookingQuerier interface {
-	GetFinishedBookings(ctx context.Context) ([]postgres.FinishedBooking, error)
+	GetFinishedBookings(ctx context.Context, f postgres.FinishedBookingFilter) ([]postgres.FinishedBooking, error)
 }
 
 type HttpRouter struct {
@@ -40,7 +42,23 @@ func NewRouter(querier BookingQuerier) *HttpRouter {
 }
 
 func (h *HttpRouter) getFinishedBookings(c *gin.Context) {
-	bookings, err := h.querier.GetFinishedBookings(c.Request.Context())
+	var f postgres.FinishedBookingFilter
+	if y := c.Query("year"); y != "" {
+		if v, err := strconv.Atoi(y); err == nil {
+			f.Year = &v
+		}
+	}
+	if m := c.Query("month"); m != "" {
+		if v, err := strconv.Atoi(m); err == nil {
+			f.Month = &v
+		}
+	}
+	if u := c.Query("user_ref"); u != "" {
+		if id, err := uuid.Parse(u); err == nil {
+			f.UserRef = &id
+		}
+	}
+	bookings, err := h.querier.GetFinishedBookings(c.Request.Context(), f)
 	if err != nil {
 		log.Ctx(c.Request.Context()).Error().Err(err).Msg("failed to get finished bookings")
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to retrieve finished bookings"})

--- a/ui/bilcool-ui/nginx.conf
+++ b/ui/bilcool-ui/nginx.conf
@@ -13,6 +13,10 @@ server {
         proxy_pass http://event-ledger:8080/;
     }
 
+    location /api/journal/ {
+        proxy_pass http://journal:8080/;
+    }
+
     location / {
         root /usr/share/nginx/html;
         try_files $uri $uri/ /index.html;

--- a/ui/bilcool-ui/src/api/events.ts
+++ b/ui/bilcool-ui/src/api/events.ts
@@ -1,7 +1,8 @@
 import { apiFetch } from './client';
-import type { EventQueryParams, EventResponse } from '../types/api';
+import type { EventQueryParams, EventResponse, FinishedBooking, FinishedBookingParams } from '../types/api';
 
 const BASE = '/api/events/api/v1';
+const JOURNAL_BASE = '/api/journal/api/v1';
 
 export const listEvents = (params: EventQueryParams) => {
   const qs = new URLSearchParams(
@@ -10,4 +11,13 @@ export const listEvents = (params: EventQueryParams) => {
       .map(([k, v]) => [k, String(v)])
   ).toString();
   return apiFetch<EventResponse[]>(`${BASE}/events${qs ? `?${qs}` : ''}`);
+};
+
+export const listFinishedBookings = (params: FinishedBookingParams) => {
+  const qs = new URLSearchParams(
+    Object.entries(params)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => [k, String(v)])
+  ).toString();
+  return apiFetch<FinishedBooking[]>(`${JOURNAL_BASE}/bookings${qs ? `?${qs}` : ''}`);
 };

--- a/ui/bilcool-ui/src/pages/BookingsPage.tsx
+++ b/ui/bilcool-ui/src/pages/BookingsPage.tsx
@@ -1,78 +1,110 @@
 import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
 import { useTranslation } from 'react-i18next'
 import { useBookings } from '../hooks/useBookings'
-import { useUsers } from '../hooks/useUsers'
+import { useAllUsers } from '../hooks/useUsers'
 import { useAuthStore } from '../stores/authStore'
 import { useSettingsStore } from '../stores/settingsStore'
 import type { BookingResponse } from '../types/api'
 import { formatDate, formatTime, formatMonthYear, formatMonthKey } from '../utils/dateUtils'
+import { listFinishedBookings } from '../api/events'
 
-type BookingStatus = 'upcoming' | 'active' | 'completed' | 'overdue'
+type BookingStatus = 'upcoming' | 'active' | 'overdue'
 
-function getStatus(booking: BookingResponse, hasDistance: boolean): BookingStatus {
+function getStatus(booking: BookingResponse): BookingStatus {
   const now = new Date()
   const start = new Date(booking.start_date)
   const end = new Date(booking.end_date)
-  if (hasDistance) return 'completed'
   if (start <= now && now < end) return 'active'
   if (end < now) return 'overdue'
   return 'upcoming'
 }
 
+const currentYear = new Date().getFullYear()
+const currentMonth = String(new Date().getMonth() + 1)
+
 export default function BookingsPage() {
   const { t } = useTranslation('bookings')
   const language = useSettingsStore((s) => s.language)
   const userRef = useAuthStore((s) => s.userRef)
-  const role = useAuthStore((s) => s.role)
 
-  const { data: bookings = [] } = useBookings()
-
-  const completedBookingMap = new Map<string, number>()
-  for (const b of bookings) {
-    if (b.distance) {
-      const km = (b.distance.end_distance - b.distance.start_distance) / 1000
-      completedBookingMap.set(b.booking_reference, km)
-    }
-  }
-
-  const uniqueUserRefs = [...new Set(bookings.map((b) => b.user_ref))]
-  const userQueries = useUsers(uniqueUserRefs)
-  const userMap = new Map(
-    userQueries
-      .map((q) => q.data)
-      .filter(Boolean)
-      .map((u) => [u!.user_ref, u!.username])
-  )
-
-  const allMonthKeys = [...new Set(bookings.map((b) => formatMonthKey(b.start_date)))].sort()
-
-  const [selectedMonth, setSelectedMonth] = useState<string>(allMonthKeys[allMonthKeys.length - 1] ?? '')
+  const [selectedYear, setSelectedYear] = useState<number>(currentYear)
+  const [selectedMonth, setSelectedMonth] = useState<string>(currentMonth)
   const [selectedUser, setSelectedUser] = useState<string>('all')
 
-  const monthlySummary = allMonthKeys.map((monthKey) => {
-    const inMonth = bookings.filter((b) => formatMonthKey(b.start_date) === monthKey)
-    const myInMonth = inMonth.filter((b) => b.user_ref === userRef)
-    const myKm = myInMonth.reduce((sum, b) => {
-      const km = completedBookingMap.get(b.booking_reference)
-      return sum + (km ?? 0)
-    }, 0)
+  const userFilter = selectedUser !== 'all' ? selectedUser : undefined
+
+  const { data: allBookings = [] } = useBookings()
+  const nonCompleted = allBookings.filter((b) => !b.distance)
+
+  const summaryParams = { year: selectedYear, user_ref: userFilter }
+  const { data: finishedBookingsAll = [] } = useQuery({
+    queryKey: ['finishedBookings', summaryParams],
+    queryFn: () => listFinishedBookings(summaryParams),
+    staleTime: 30_000,
+  })
+
+  const listParams = {
+    year: selectedYear,
+    month: selectedMonth ? Number(selectedMonth) : undefined,
+    user_ref: userFilter,
+  }
+  const { data: finishedBookings = [] } = useQuery({
+    queryKey: ['finishedBookings', listParams],
+    queryFn: () => listFinishedBookings(listParams),
+    staleTime: 30_000,
+  })
+
+  const { data: allUsers = [] } = useAllUsers()
+  const userMap = new Map(allUsers.map((u) => [u.user_ref, u.username]))
+
+  const availableYears = [
+    ...new Set([
+      currentYear,
+      ...allBookings.map((b) => new Date(b.start_date).getFullYear()),
+      ...finishedBookingsAll.map((b) => new Date(b.start_date).getFullYear()),
+    ]),
+  ].sort((a, b) => b - a)
+
+  const monthsInYear = [
+    ...new Set([
+      ...allBookings
+        .filter((b) => new Date(b.start_date).getFullYear() === selectedYear)
+        .map((b) => formatMonthKey(b.start_date).split('-')[1]),
+      ...finishedBookingsAll.map((b) => formatMonthKey(b.start_date).split('-')[1]),
+    ]),
+  ].sort()
+
+  const nonCompletedInYear = nonCompleted.filter(
+    (b) => new Date(b.start_date).getFullYear() === selectedYear
+  )
+
+  const filteredNonCompleted = nonCompletedInYear.filter((b) => {
+    if (selectedMonth && formatMonthKey(b.start_date).split('-')[1] !== selectedMonth) return false
+    if (userFilter && b.user_ref !== userFilter) return false
+    return true
+  })
+
+  const monthlySummary = monthsInYear.map((monthNum) => {
+    const inMonth = (b: { start_date: string }) =>
+      formatMonthKey(b.start_date).split('-')[1] === monthNum
+
+    const myNonCompleted = nonCompletedInYear.filter(
+      (b) => inMonth(b) && b.user_ref === userRef
+    )
+    const myFinished = finishedBookingsAll.filter(
+      (b) => inMonth(b) && b.user_ref === (userRef ?? '')
+    )
+    const myKm = myFinished.reduce((sum, b) => sum + b.distance_meters / 1000, 0)
+
     return {
-      monthKey,
-      label: formatMonthYear(new Date(monthKey + '-01'), language),
-      myCount: myInMonth.length,
-      totalCount: inMonth.length,
+      monthKey: `${selectedYear}-${monthNum}`,
+      label: formatMonthYear(new Date(`${selectedYear}-${monthNum}-01`), language),
+      myCount: myNonCompleted.length + myFinished.length,
+      totalCount: nonCompletedInYear.filter(inMonth).length + finishedBookingsAll.filter(inMonth).length,
       myKm,
     }
   })
-
-  const filteredBookings = bookings
-    .filter((b) => {
-      if (selectedMonth && formatMonthKey(b.start_date) !== selectedMonth) return false
-      if (role !== 'admin' && b.user_ref !== userRef) return false
-      if (role === 'admin' && selectedUser !== 'all' && b.user_ref !== selectedUser) return false
-      return true
-    })
-    .sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime())
 
   return (
     <div className="space-y-6">
@@ -109,6 +141,20 @@ export default function BookingsPage() {
 
         <div className="flex flex-wrap gap-3 mb-4">
           <div>
+            <label htmlFor="year-filter" className="text-sm font-medium mr-2">Year</label>
+            <select
+              id="year-filter"
+              value={selectedYear}
+              onChange={(e) => { setSelectedYear(Number(e.target.value)); setSelectedMonth(currentMonth) }}
+              className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+            >
+              {availableYears.map((y) => (
+                <option key={y} value={y}>{y}</option>
+              ))}
+            </select>
+          </div>
+
+          <div>
             <label htmlFor="month-filter" className="text-sm font-medium mr-2">
               {t('filter_month')}
             </label>
@@ -118,38 +164,36 @@ export default function BookingsPage() {
               onChange={(e) => setSelectedMonth(e.target.value)}
               className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
             >
-              <option value="">{t('filter_all_users')}</option>
-              {allMonthKeys.map((mk) => (
-                <option key={mk} value={mk}>
-                  {formatMonthYear(new Date(mk + '-01'), language)}
+              <option value="">All months</option>
+              {monthsInYear.map((m) => (
+                <option key={m} value={m}>
+                  {formatMonthYear(new Date(`${selectedYear}-${m}-01`), language)}
                 </option>
               ))}
             </select>
           </div>
 
-          {role === 'admin' && (
-            <div>
-              <label htmlFor="user-filter" className="text-sm font-medium mr-2">
-                {t('filter_user')}
-              </label>
-              <select
-                id="user-filter"
-                value={selectedUser}
-                onChange={(e) => setSelectedUser(e.target.value)}
-                className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
-              >
-                <option value="all">{t('filter_all_users')}</option>
-                {uniqueUserRefs.map((ref) => (
-                  <option key={ref} value={ref}>
-                    {userMap.get(ref) ?? ref}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+          <div>
+            <label htmlFor="user-filter" className="text-sm font-medium mr-2">
+              {t('filter_user')}
+            </label>
+            <select
+              id="user-filter"
+              value={selectedUser}
+              onChange={(e) => setSelectedUser(e.target.value)}
+              className="rounded-md border border-input bg-background px-3 py-1.5 text-sm"
+            >
+              <option value="all">{t('filter_all_users')}</option>
+              {allUsers.map((u) => (
+                <option key={u.user_ref} value={u.user_ref}>
+                  {u.username}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
 
-        {filteredBookings.length === 0 ? (
+        {filteredNonCompleted.length === 0 && finishedBookings.length === 0 ? (
           <p className="text-muted-foreground text-sm">{t('no_bookings')}</p>
         ) : (
           <>
@@ -166,42 +210,56 @@ export default function BookingsPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {filteredBookings.map((b) => {
-                    const hasDistance = completedBookingMap.has(b.booking_reference)
-                    const km = completedBookingMap.get(b.booking_reference)
-                    const status = getStatus(b, hasDistance)
-                    return (
+                  {finishedBookings.map((b) => (
+                    <tr key={b.booking_reference} className="border-b last:border-0">
+                      <td className="px-4 py-3">{userMap.get(b.user_ref) ?? b.user_ref}</td>
+                      <td className="px-4 py-3">{formatDate(b.start_date, language)}</td>
+                      <td className="px-4 py-3">{formatTime(b.start_date, language)}</td>
+                      <td className="px-4 py-3">{formatTime(b.end_date, language)}</td>
+                      <td className="px-4 py-3">{(b.distance_meters / 1000).toFixed(1)}</td>
+                      <td className="px-4 py-3">{t('status_completed')}</td>
+                    </tr>
+                  ))}
+                  {filteredNonCompleted
+                    .sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime())
+                    .map((b) => (
                       <tr key={b.booking_reference} className="border-b last:border-0">
                         <td className="px-4 py-3">{userMap.get(b.user_ref) ?? b.user_ref}</td>
                         <td className="px-4 py-3">{formatDate(b.start_date, language)}</td>
                         <td className="px-4 py-3">{formatTime(b.start_date, language)}</td>
                         <td className="px-4 py-3">{formatTime(b.end_date, language)}</td>
-                        <td className="px-4 py-3">{km !== undefined ? km.toFixed(1) : '—'}</td>
-                        <td className="px-4 py-3">{t(`status_${status}`)}</td>
+                        <td className="px-4 py-3">—</td>
+                        <td className="px-4 py-3">{t(`status_${getStatus(b)}`)}</td>
                       </tr>
-                    )
-                  })}
+                    ))}
                 </tbody>
               </table>
             </div>
 
             <div className="md:hidden grid gap-3">
-              {filteredBookings.map((b) => {
-                const hasDistance = completedBookingMap.has(b.booking_reference)
-                const km = completedBookingMap.get(b.booking_reference)
-                const status = getStatus(b, hasDistance)
-                return (
+              {finishedBookings.map((b) => (
+                <div key={b.booking_reference} className="rounded-lg border bg-card p-4 space-y-1 text-sm">
+                  <div className="flex justify-between items-start">
+                    <span className="font-medium">{userMap.get(b.user_ref) ?? b.user_ref}</span>
+                    <span className="text-xs text-muted-foreground">{t('status_completed')}</span>
+                  </div>
+                  <p className="text-muted-foreground">{formatDate(b.start_date, language)}</p>
+                  <p>{formatTime(b.start_date, language)} – {formatTime(b.end_date, language)}</p>
+                  <p>{(b.distance_meters / 1000).toFixed(1)} km</p>
+                </div>
+              ))}
+              {filteredNonCompleted
+                .sort((a, b) => new Date(b.start_date).getTime() - new Date(a.start_date).getTime())
+                .map((b) => (
                   <div key={b.booking_reference} className="rounded-lg border bg-card p-4 space-y-1 text-sm">
                     <div className="flex justify-between items-start">
                       <span className="font-medium">{userMap.get(b.user_ref) ?? b.user_ref}</span>
-                      <span className="text-xs text-muted-foreground">{t(`status_${status}`)}</span>
+                      <span className="text-xs text-muted-foreground">{t(`status_${getStatus(b)}`)}</span>
                     </div>
                     <p className="text-muted-foreground">{formatDate(b.start_date, language)}</p>
                     <p>{formatTime(b.start_date, language)} – {formatTime(b.end_date, language)}</p>
-                    {km !== undefined && <p>{km.toFixed(1)} km</p>}
                   </div>
-                )
-              })}
+                ))}
             </div>
           </>
         )}

--- a/ui/bilcool-ui/src/types/api.ts
+++ b/ui/bilcool-ui/src/types/api.ts
@@ -88,6 +88,20 @@ export interface EventQueryParams {
   order_direction?: 'asc' | 'desc';
 }
 
+export interface FinishedBooking {
+  booking_reference: string
+  user_ref: string
+  start_date: string
+  end_date: string
+  distance_meters: number
+}
+
+export interface FinishedBookingParams {
+  year?: number
+  month?: number
+  user_ref?: string
+}
+
 export interface CompletedBookingPayload {
   booking: BookingResponse;
   distance: {

--- a/ui/bilcool-ui/vite.config.ts
+++ b/ui/bilcool-ui/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       '/api/auth': { target: process.env.AUTH_SERVICE_URL ?? 'http://localhost:8082', rewrite: (path) => path.replace('/api/auth', '') },
       '/api/book': { target: process.env.BOOK_SERVICE_URL ?? 'http://localhost:8081', rewrite: (path) => path.replace('/api/book', '') },
       '/api/events': { target: process.env.EVENTS_SERVICE_URL ?? 'http://localhost:8083', rewrite: (path) => path.replace('/api/events', '') },
+      '/api/journal': { target: process.env.JOURNAL_SERVICE_URL ?? 'http://localhost:8084', rewrite: (path) => path.replace('/api/journal', '') },
     },
   },
   test: {


### PR DESCRIPTION
The BookingsPage was calling /api/events/api/v1/bookings which proxied to the event-ledger service, but the GET /api/v1/bookings endpoint lives in the journal service. Added /api/journal proxy in vite.config.ts and nginx.conf pointing at journal:8080, and updated listFinishedBookings to use JOURNAL_BASE. Also includes the backend filter changes (year/month/user_ref) and BookingsPage UI updates that were part of the same feature.