### PR TITLE
fix: initialize outbox table in Lambda HTTP handlers and tune connection pooling for Neon

### DIFF
--- a/authentication/cmd/lambda/http/main.go
+++ b/authentication/cmd/lambda/http/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/persistance/postgresql"
 	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/web"
 	ginadapter "github.com/awslabs/aws-lambda-go-api-proxy/gin"
+	coutbox "github.com/arngrimur/bilcool_monolith/message_broker/pkg/postgres"
 )
 
 func main() {
@@ -36,6 +37,9 @@ func main() {
 	}
 
 	db := postgresql.SetupPostgresDatabase()
+	if err := coutbox.CreateTable(db); err != nil {
+		log.Fatal().Err(err).Msg("error creating outbox table")
+	}
 	repo := postgresql.NewUsersRepository(db)
 	mailSender := brevo.NewSender()
 	app := application.New(repo, mailSender, wauthn, config.JWTSecret())

--- a/authentication/internal/pkg/persistance/postgresql/setup.go
+++ b/authentication/internal/pkg/persistance/postgresql/setup.go
@@ -2,6 +2,7 @@ package postgresql
 
 import (
 	"database/sql"
+	"os"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -21,10 +22,17 @@ func SetupPostgresDatabase() *sql.DB {
 			log.Err(err).Msgf("error pinging database, attempt: %d", i)
 		} else {
 			log.Info().Msg("database connection successful")
-			psqlDb.SetMaxOpenConns(5)
-			psqlDb.SetMaxIdleConns(5)
-			psqlDb.SetConnMaxLifetime(4 * time.Minute)
-			psqlDb.SetConnMaxIdleTime(2 * time.Minute)
+			if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
+				psqlDb.SetMaxOpenConns(2)
+				psqlDb.SetMaxIdleConns(0)
+				psqlDb.SetConnMaxLifetime(30 * time.Second)
+				psqlDb.SetConnMaxIdleTime(0)
+			} else {
+				psqlDb.SetMaxOpenConns(5)
+				psqlDb.SetMaxIdleConns(5)
+				psqlDb.SetConnMaxLifetime(4 * time.Minute)
+				psqlDb.SetConnMaxIdleTime(2 * time.Minute)
+			}
 			return psqlDb
 		}
 	}

--- a/bookings/cmd/lambda/http/main.go
+++ b/bookings/cmd/lambda/http/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/config"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/persistance/postgresql"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/web"
+	coutbox "github.com/arngrimur/bilcool_monolith/message_broker/pkg/postgres"
 )
 
 func main() {
@@ -25,6 +26,9 @@ func main() {
 	}
 
 	db := postgresql.SetupPostgresDatabase()
+	if err := coutbox.CreateTable(db); err != nil {
+		log.Fatal().Err(err).Msg("error creating outbox table")
+	}
 	repo := postgresql.NewBookingsRepository(db)
 	app := application.New(repo)
 	ginLambda := ginadapter.NewV2(web.NewRouter(app.GetBookingsHandler, app.UpdateBookingsHandler).Engine())

--- a/bookings/internal/pkg/persistance/postgresql/setup.go
+++ b/bookings/internal/pkg/persistance/postgresql/setup.go
@@ -2,6 +2,7 @@ package postgresql
 
 import (
 	"database/sql"
+	"os"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -22,10 +23,17 @@ func SetupPostgresDatabase() *sql.DB {
 			log.Err(err).Msgf("error pinging database, attempt: %d", i)
 		} else {
 			log.Info().Msg("database connection successful")
-			psqlDb.SetMaxOpenConns(5)
-			psqlDb.SetMaxIdleConns(5)
-			psqlDb.SetConnMaxLifetime(4 * time.Minute)
-			psqlDb.SetConnMaxIdleTime(2 * time.Minute)
+			if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
+				psqlDb.SetMaxOpenConns(2)
+				psqlDb.SetMaxIdleConns(0)
+				psqlDb.SetConnMaxLifetime(30 * time.Second)
+				psqlDb.SetConnMaxIdleTime(0)
+			} else {
+				psqlDb.SetMaxOpenConns(5)
+				psqlDb.SetMaxIdleConns(5)
+				psqlDb.SetConnMaxLifetime(4 * time.Minute)
+				psqlDb.SetConnMaxIdleTime(2 * time.Minute)
+			}
 			return psqlDb
 		}
 	}

--- a/infrastructure/dev/docker-compose.yaml
+++ b/infrastructure/dev/docker-compose.yaml
@@ -121,6 +121,7 @@ services:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-test}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-test}
       AWS_ENDPOINT_URL: http://localstack:4566
+      OUTBOX_MODE: replication
     ports: ["8081:8080"]
     networks:
       - bilcool
@@ -141,6 +142,7 @@ services:
       AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-test}
       AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-test}
       AWS_ENDPOINT_URL: http://localstack:4566
+      OUTBOX_MODE: replication
       JWT_SECRET: ${JWT_SECRET:-changeme}
       FROM_EMAIL: ${FROM_EMAIL}
       BREVO_API_KEY: ${BREVO_API_KEY}


### PR DESCRIPTION
Lambda HTTP handlers for authentication and bookings were missing the
coutbox.CreateTable() call that the traditional server performs at startup.
Every CreateUser/booking write atomically inserts into the outbox table, so
the table must exist before the first request — without it every write fails.

Also adds Lambda-aware connection pool settings (detected via
AWS_LAMBDA_FUNCTION_NAME): 2 max open connections with no idle connections
and a 30s lifetime, preventing connection exhaustion on Neon's limited
connection pool when multiple Lambda containers are active concurrently.

Dev docker-compose now explicitly sets OUTBOX_MODE=replication for both
services so the mode is visible and intentional, matching local Postgres
WAL capabilities.

https://claude.ai/code/session_01H1rS82dyjaNY3Dyp2iwcq6