### PR TITLE
ci: add terraform-apply job on push to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,6 +318,38 @@ jobs:
         run: terraform validate
         working-directory: infrastructure/production/terraform
 
+  terraform-apply:
+    name: terraform-apply
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.9"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: eu-north-1
+      - name: Terraform init
+        run: terraform init
+        working-directory: infrastructure/production/terraform
+      - name: Terraform apply
+        run: terraform apply -auto-approve
+        working-directory: infrastructure/production/terraform
+        env:
+          TF_VAR_neon_api_key: ${{ secrets.TF_VAR_NEON_API_KEY }}
+          TF_VAR_jwt_secret: ${{ secrets.TF_VAR_JWT_SECRET }}
+          TF_VAR_brevo_api_key: ${{ secrets.TF_VAR_BREVO_API_KEY }}
+          TF_VAR_from_email: ${{ secrets.TF_VAR_FROM_EMAIL }}
+          TF_VAR_webauthn_rp_id: ${{ secrets.TF_VAR_WEBAUTHN_RP_ID }}
+          TF_VAR_webauthn_rp_origins: ${{ secrets.TF_VAR_WEBAUTHN_RP_ORIGINS }}
+          TF_VAR_lambda_artifacts_bucket: bilcool-lambda-artifacts
+
   build-ui:
     name: ui
     runs-on: ubuntu-latest


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
- Adds a `terraform-apply` job that runs automatically on every push to `main`
- Uses OIDC (`AWS_DEPLOY_ROLE_ARN`) to authenticate, same as `lambda-deploy` and `ui-deploy`
- Passes all required Terraform variables via GitHub Secrets (`TF_VAR_*`)
- `lambda_artifacts_bucket` is hardcoded (`bilcool-lambda-artifacts`) as it matches the value already used in `lambda-deploy`
- Runs independently of `lambda-deploy` (infrastructure and code deploys are parallel)

## Required GitHub Secrets
The following secrets must be set in the repository before this job will succeed:
- `TF_VAR_NEON_API_KEY`
- `TF_VAR_JWT_SECRET`
- `TF_VAR_BREVO_API_KEY`
- `TF_VAR_FROM_EMAIL`
- `TF_VAR_WEBAUTHN_RP_ID`
- `TF_VAR_WEBAUTHN_RP_ORIGINS`

## Test plan
- [ ] Verify the required GitHub Secrets are configured
- [ ] Confirm `terraform-apply` runs and succeeds on merge to main
- [ ] Confirm API Gateway root routes for bookings and event_ledger are applied

https://claude.ai/code/session_01GmNNtqYac8bJ5fSf1gAXjs
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmNNtqYac8bJ5fSf1gAXjs)_