### PR TITLE
fix: edit booking click handler uses stale extendedProps.isOwn

### DIFF
--- a/ui/bilcool-ui/src/api/client.ts
+++ b/ui/bilcool-ui/src/api/client.ts
@@ -17,5 +17,7 @@ export async function apiFetch<T>(input: RequestInfo, init?: RequestInit): Promi
     throw Object.assign(new Error(err.message ?? 'Request failed'), { status: res.status, body: err });
   }
   if (res.status === 204 || res.headers.get('content-length') === '0') return undefined as T;
-  return res.json();
+  const text = await res.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
 }

--- a/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
+++ b/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
@@ -82,8 +82,7 @@ export default function CalendarView({ completedBookingMap }: CalendarViewProps)
 
   function handleEventClick(arg: EventClickArg) {
     const booking = arg.event.extendedProps['booking'] as BookingResponse
-    const isOwn = arg.event.extendedProps['isOwn'] as boolean
-    if (!isOwn) return
+    if (!booking || booking.user_ref !== userRef) return
     setSelectedBooking(booking)
     setDetailOpen(true)
   }


### PR DESCRIPTION
FullCalendar does not reliably propagate React prop updates into
extendedProps after async auth initialisation, so isOwn could remain
false or undefined for the current user's own bookings, silently
blocking the detail dialog.

Replace the stale extendedProps.isOwn guard with a live comparison of
booking.user_ref against the current userRef from the auth store.

Also harden apiFetch to parse the response body via res.text() before
JSON.parse so that a 202 with no Content-Length header (e.g. after
going through a proxy) does not throw a SyntaxError.

https://claude.ai/code/session_01MeGHYYDmbydFenyH1oSBCA