### PR TITLE
fix: stale confirmCancel state hides Edit Booking button on reopen

### DIFF
--- a/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
+++ b/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
@@ -52,6 +52,10 @@ export default function BookingStartEndDialog({
   const deleteBooking = useDeleteBooking()
   const endBooking = useEndBooking()
   const [confirmCancel, setConfirmCancel] = useState(false)
+
+  useEffect(() => {
+    if (!open) setConfirmCancel(false)
+  }, [open])
 
   const now = new Date()
   const startDate = new Date(booking.start_date)


### PR DESCRIPTION
## Summary

- `BookingStartEndDialog` kept `confirmCancel=true` across dialog sessions. If a user opened the cancel-confirmation flow and then dismissed the dialog (Escape / backdrop click) without going Back or confirming, the next time they clicked any booking the `isFuture && !confirmCancel` guard evaluated to `false` — silently hiding the **Edit Booking** button even for future bookings the user owns.
- Fix: add a `useEffect` that resets `confirmCancel` to `false` whenever the dialog closes (`open` transitions to `false`), so every open starts from a clean state.

## Test plan

- [ ] Click a booking → click "Cancel Booking" → press Escape to dismiss without confirming
- [ ] Click the same (or a different) future booking → "Edit Booking" button is visible again
- [ ] Full edit flow still works end-to-end: click booking → Edit → change times → Save → calendar updates

https://claude.ai/code/session_01MeGHYYDmbydFenyH1oSBCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeGHYYDmbydFenyH1oSBCA)_