### PR TITLE
fix: datetime-local inputs show invalid value due to step=900

### DIFF
--- a/ui/bilcool-ui/src/components/bookings/BookingForm.tsx
+++ b/ui/bilcool-ui/src/components/bookings/BookingForm.tsx
@@ -113,13 +113,12 @@ export default function BookingForm({
           <DialogTitle>{title}</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" id="booking-form">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" id="booking-form" noValidate>
           <div className="space-y-2">
             <Label htmlFor="booking-start">{t('form_start')}</Label>
             <Input
               id="booking-start"
               type="datetime-local"
-              step={900}
               {...register('start')}
               aria-describedby={errors.start ? 'start-error' : undefined}
             />
@@ -135,7 +134,6 @@ export default function BookingForm({
             <Input
               id="booking-end"
               type="datetime-local"
-              step={900}
               {...register('end')}
               aria-describedby={errors.end ? 'end-error' : undefined}
             />


### PR DESCRIPTION
## Summary

- `step={900}` on the `datetime-local` inputs caused browsers that don't enforce the step in their native picker UI (Firefox, Safari) to immediately mark the field as invalid after the user picked any non-15-minute time. The form element was also missing `noValidate`, so the browser's constraint validation ran alongside Zod's, producing the confusing "invalid value" tooltip.
- Fix: remove `step` from both inputs and add `noValidate` to the form. Time alignment is already handled by `snapToQuarterHour` in `onSubmit`, so the step attribute was only a UI hint that caused more harm than good.

## Test plan

- [ ] Open the booking form (create or edit) — no "invalid value" error when selecting any date/time from the native picker
- [ ] Select a non-15-minute time (e.g. 10:07) — form submits and snaps silently to the nearest quarter hour
- [ ] Form validation (end before start, min duration, overlap) still fires correctly on submit

https://claude.ai/code/session_01MeGHYYDmbydFenyH1oSBCA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeGHYYDmbydFenyH1oSBCA)_