### PR TITLE
Add GPS position to end booking flow

### DIFF
--- a/bookings/internal/migrations/20260501000000_add_position_to_distances.sql
+++ b/bookings/internal/migrations/20260501000000_add_position_to_distances.sql
@@ -1,7 +1,10 @@
 -- migrate:up
-ALTER TABLE distances ADD COLUMN lat DOUBLE PRECISION;
-ALTER TABLE distances ADD COLUMN lon DOUBLE PRECISION;
+CREATE TABLE positions (
+    id           SERIAL PRIMARY KEY,
+    fk_booking_id INT NOT NULL REFERENCES bookings(id),
+    lat          DOUBLE PRECISION NOT NULL,
+    lon          DOUBLE PRECISION NOT NULL
+);
 
 -- migrate:down
-ALTER TABLE distances DROP COLUMN lat;
-ALTER TABLE distances DROP COLUMN lon;
+DROP TABLE positions;

--- a/bookings/internal/migrations/20260501000000_add_position_to_distances.sql
+++ b/bookings/internal/migrations/20260501000000_add_position_to_distances.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE distances ADD COLUMN lat DOUBLE PRECISION;
+ALTER TABLE distances ADD COLUMN lon DOUBLE PRECISION;
+
+-- migrate:down
+ALTER TABLE distances DROP COLUMN lat;
+ALTER TABLE distances DROP COLUMN lon;

--- a/bookings/internal/pkg/domain/bookings.go
+++ b/bookings/internal/pkg/domain/bookings.go
@@ -22,6 +22,7 @@ type BookingRequest struct {
 type EndBookingRequest struct {
 	BookingRequest
 	extdomain.Distance
+	Position *extdomain.Position
 }
 
 func NewBookingResponse(bookingRef uuid.UUID, startTime time.Time, endTime time.Time, userRef uuid.UUID, distance *extdomain.Distance) extdomain.BookingResponse {

--- a/bookings/internal/pkg/persistance/postgresql/bookings.go
+++ b/bookings/internal/pkg/persistance/postgresql/bookings.go
@@ -173,13 +173,19 @@ func (bdb BookingRepository) EndBooking(ctx context.Context, request domain.EndB
 	if err != nil {
 		return err
 	}
-	q := "INSERT INTO distances (fk_booking_id, start_distance, end_distance) VALUES ($1, $2, $3)"
-	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.StartDistance, request.EndDistance)
+	var lat, lon *float64
+	if request.Position != nil {
+		lat = &request.Position.Lat
+		lon = &request.Position.Lon
+	}
+	q := "INSERT INTO distances (fk_booking_id, start_distance, end_distance, lat, lon) VALUES ($1, $2, $3, $4, $5)"
+	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.StartDistance, request.EndDistance, lat, lon)
 	if err != nil {
 		return err
 	}
 	// insert msg in outbox
 	booking.completed.Distance = request.Distance
+	booking.completed.Position = request.Position
 
 	bytes, err := json.Marshal(booking.completed)
 	if err != nil {

--- a/bookings/internal/pkg/persistance/postgresql/bookings.go
+++ b/bookings/internal/pkg/persistance/postgresql/bookings.go
@@ -173,15 +173,18 @@ func (bdb BookingRepository) EndBooking(ctx context.Context, request domain.EndB
 	if err != nil {
 		return err
 	}
-	var lat, lon *float64
-	if request.Position != nil {
-		lat = &request.Position.Lat
-		lon = &request.Position.Lon
-	}
-	q := "INSERT INTO distances (fk_booking_id, start_distance, end_distance, lat, lon) VALUES ($1, $2, $3, $4, $5)"
-	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.StartDistance, request.EndDistance, lat, lon)
+	q := "INSERT INTO distances (fk_booking_id, start_distance, end_distance) VALUES ($1, $2, $3)"
+	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.StartDistance, request.EndDistance)
 	if err != nil {
 		return err
+	}
+	if request.Position != nil {
+		_, err = local_bdb.ExecContext(ctx,
+			"INSERT INTO positions (fk_booking_id, lat, lon) VALUES ($1, $2, $3)",
+			booking.id, request.Position.Lat, request.Position.Lon)
+		if err != nil {
+			return err
+		}
 	}
 	// insert msg in outbox
 	booking.completed.Distance = request.Distance

--- a/bookings/internal/pkg/persistance/postgresql/bookings_test.go
+++ b/bookings/internal/pkg/persistance/postgresql/bookings_test.go
@@ -20,6 +20,7 @@ import (
 
 	_ "github.com/lib/pq"
 
+	extdomain "github.com/arngrimur/bilcool_monolith/bookings/pkg/domain"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/domain"
 )
 
@@ -35,6 +36,8 @@ type bookingsTestSuite struct {
 
 func (suite *bookingsTestSuite) SetupSuite() {
 	suite.SuiteDbIntegration = testdb.SetupDatabase(suite.T(), migrations.FS, "bookings_test")
+	err := brokerpostgres.CreateTable(suite.ConnString)
+	suite.Require().NoError(err)
 	suite.bookingRef = uuid.New()
 	suite.userRef = uuid.New()
 	suite.startTime = time.Now().Add(time.Hour).UTC()
@@ -61,7 +64,7 @@ func (suite *bookingsTestSuite) BeforeTest(suiteName, testName string) {
 }
 
 func (suite *bookingsTestSuite) AfterTest(suiteName, testName string) {
-	_, err := suite.Db.Exec("TRUNCATE TABLE users, inbox CASCADE")
+	_, err := suite.Db.Exec("TRUNCATE TABLE users, inbox, outbox CASCADE")
 	suite.Require().NoError(err)
 }
 
@@ -314,6 +317,54 @@ func (suite *bookingsTestSuite) TestDeleteUserDuplicateMessageID() {
 
 	err = database.DeleteUser(context.Background(), makeUserMessage(userRef, messageID))
 	suite.Require().Error(err)
+}
+
+func (suite *bookingsTestSuite) TestEndBookingWithPosition() {
+	database := NewBookingsRepository(suite.Db)
+	pos := &extdomain.Position{Lat: 64.128288, Lon: -21.827774}
+
+	err := database.EndBooking(context.Background(), domain.EndBookingRequest{
+		BookingRequest: domain.BookingRequest{BookingReference: suite.bookingRef},
+		Distance:       extdomain.Distance{StartDistance: 0, EndDistance: 12500},
+		Position:       pos,
+	})
+	suite.Require().NoError(err)
+
+	var startDist, endDist int
+	err = suite.Db.QueryRow(`
+		SELECT d.start_distance, d.end_distance
+		FROM distances d JOIN bookings b ON d.fk_booking_id = b.id
+		WHERE b.booking_reference = $1`, suite.bookingRef).Scan(&startDist, &endDist)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, startDist)
+	suite.Require().Equal(12500, endDist)
+
+	var lat, lon float64
+	err = suite.Db.QueryRow(`
+		SELECT p.lat, p.lon
+		FROM positions p JOIN bookings b ON p.fk_booking_id = b.id
+		WHERE b.booking_reference = $1`, suite.bookingRef).Scan(&lat, &lon)
+	suite.Require().NoError(err)
+	suite.Require().InDelta(pos.Lat, lat, 0.000001)
+	suite.Require().InDelta(pos.Lon, lon, 0.000001)
+}
+
+func (suite *bookingsTestSuite) TestEndBookingWithoutPosition() {
+	database := NewBookingsRepository(suite.Db)
+
+	err := database.EndBooking(context.Background(), domain.EndBookingRequest{
+		BookingRequest: domain.BookingRequest{BookingReference: suite.bookingRef},
+		Distance:       extdomain.Distance{StartDistance: 0, EndDistance: 8000},
+	})
+	suite.Require().NoError(err)
+
+	var count int
+	err = suite.Db.QueryRow(`
+		SELECT COUNT(*)
+		FROM positions p JOIN bookings b ON p.fk_booking_id = b.id
+		WHERE b.booking_reference = $1`, suite.bookingRef).Scan(&count)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, count)
 }
 
 func makeUserMessage(userRef uuid.UUID, messageID string) brokerpostgres.Message {

--- a/bookings/internal/pkg/web/router.go
+++ b/bookings/internal/pkg/web/router.go
@@ -226,15 +226,19 @@ func (h *HttpRouter) endBooking(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid format or missing id"})
 		return
 	}
-	distance := extdomain.Distance{}
-	err = c.ShouldBindBodyWithJSON(&distance)
+	var body struct {
+		extdomain.Distance
+		Position *extdomain.Position `json:"position,omitempty"`
+	}
+	err = c.ShouldBindBodyWithJSON(&body)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
 		return
 	}
 	err = h.commands.EndBooking(c.Request.Context(), domain.EndBookingRequest{
 		BookingRequest: domain.BookingRequest{BookingReference: id},
-		Distance:       distance,
+		Distance:       body.Distance,
+		Position:       body.Position,
 	})
 	if err != nil {
 		e := NewHttpError(err)

--- a/bookings/pkg/domain/completed_booking.go
+++ b/bookings/pkg/domain/completed_booking.go
@@ -8,9 +8,15 @@ import (
 
 const EventBookingEnded string = "booking.ended"
 
+type Position struct {
+	Lat float64 `json:"lat"`
+	Lon float64 `json:"lon"`
+}
+
 type CompletedBooking struct {
 	Booking  BookingResponse `json:"booking"`
 	Distance Distance        `json:"distance"`
+	Position *Position       `json:"position,omitempty"`
 }
 
 type BookingResponse struct {

--- a/journal/internal/migrations/20260501000000_add_position_to_booking_ended_events.sql
+++ b/journal/internal/migrations/20260501000000_add_position_to_booking_ended_events.sql
@@ -1,0 +1,7 @@
+-- migrate:up
+ALTER TABLE booking_ended_events ADD COLUMN lat DOUBLE PRECISION;
+ALTER TABLE booking_ended_events ADD COLUMN lon DOUBLE PRECISION;
+
+-- migrate:down
+ALTER TABLE booking_ended_events DROP COLUMN lat;
+ALTER TABLE booking_ended_events DROP COLUMN lon;

--- a/journal/internal/migrations/20260501000000_add_position_to_booking_ended_events.sql
+++ b/journal/internal/migrations/20260501000000_add_position_to_booking_ended_events.sql
@@ -1,7 +1,10 @@
 -- migrate:up
-ALTER TABLE booking_ended_events ADD COLUMN lat DOUBLE PRECISION;
-ALTER TABLE booking_ended_events ADD COLUMN lon DOUBLE PRECISION;
+CREATE TABLE positions (
+    id                        SERIAL PRIMARY KEY,
+    fk_booking_ended_event_id INT NOT NULL REFERENCES booking_ended_events(id),
+    lat                       DOUBLE PRECISION NOT NULL,
+    lon                       DOUBLE PRECISION NOT NULL
+);
 
 -- migrate:down
-ALTER TABLE booking_ended_events DROP COLUMN lat;
-ALTER TABLE booking_ended_events DROP COLUMN lon;
+DROP TABLE positions;

--- a/journal/internal/pkg/persistance/postgres/events.go
+++ b/journal/internal/pkg/persistance/postgres/events.go
@@ -18,13 +18,12 @@ import (
 var ErrDuplicateEvent = errors.New("duplicate event")
 
 type FinishedBooking struct {
-	BookingRef     uuid.UUID `json:"booking_reference"`
-	UserRef        uuid.UUID `json:"user_ref"`
-	StartDate      time.Time `json:"start_date"`
-	EndDate        time.Time `json:"end_date"`
-	DistanceMeters int       `json:"distance_meters"`
-	Lat            *float64  `json:"lat,omitempty"`
-	Lon            *float64  `json:"lon,omitempty"`
+	BookingRef     uuid.UUID        `json:"booking_reference"`
+	UserRef        uuid.UUID        `json:"user_ref"`
+	StartDate      time.Time        `json:"start_date"`
+	EndDate        time.Time        `json:"end_date"`
+	DistanceMeters int              `json:"distance_meters"`
+	Position       *domain.Position `json:"position,omitempty"`
 }
 
 type EventRepository struct {
@@ -143,15 +142,22 @@ func (r EventRepository) handleBookingEnded(ctx context.Context, payload json.Ra
 		return err
 	}
 
-	var lat, lon *float64
-	if completedBooking.Position != nil {
-		lat = &completedBooking.Position.Lat
-		lon = &completedBooking.Position.Lon
+	var eventId int64
+	q := `INSERT INTO booking_ended_events (fk_user, booking_ref, start_date, end_date, distance_meters) VALUES ($1, $2, $3, $4, $5) RETURNING id`
+	err = r.QueryRowContext(ctx, q, userId, completedBooking.Booking.BookingReference, completedBooking.Booking.StartDate, completedBooking.Booking.EndDate, completedBooking.Distance.Distance()).Scan(&eventId)
+	if err != nil {
+		return err
 	}
 
-	q := `INSERT INTO booking_ended_events (fk_user, booking_ref, start_date, end_date, distance_meters, lat, lon) VALUES ($1, $2, $3, $4, $5, $6, $7)`
-	_, err = r.ExecContext(ctx, q, userId, completedBooking.Booking.BookingReference, completedBooking.Booking.StartDate, completedBooking.Booking.EndDate, completedBooking.Distance.Distance(), lat, lon)
-	return err
+	if completedBooking.Position != nil {
+		_, err = r.ExecContext(ctx,
+			`INSERT INTO positions (fk_booking_ended_event_id, lat, lon) VALUES ($1, $2, $3)`,
+			eventId, completedBooking.Position.Lat, completedBooking.Position.Lon)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type FinishedBookingFilter struct {
@@ -162,9 +168,10 @@ type FinishedBookingFilter struct {
 
 func (r EventRepository) GetFinishedBookings(ctx context.Context, f FinishedBookingFilter) ([]FinishedBooking, error) {
 	const query = `
-SELECT b.booking_ref, u.user_ref, b.start_date, b.end_date, b.distance_meters, b.lat, b.lon
+SELECT b.booking_ref, u.user_ref, b.start_date, b.end_date, b.distance_meters, p.lat, p.lon
 FROM booking_ended_events b
 INNER JOIN users u ON b.fk_user = u.id
+LEFT JOIN positions p ON p.fk_booking_ended_event_id = b.id
 WHERE ($1::int IS NULL OR EXTRACT(YEAR  FROM b.start_date) = $1)
   AND ($2::int IS NULL OR EXTRACT(MONTH FROM b.start_date) = $2)
   AND ($3::uuid IS NULL OR u.user_ref = $3)
@@ -178,9 +185,16 @@ ORDER BY b.start_date DESC`
 
 	bookings := make([]FinishedBooking, 0)
 	for rows.Next() {
-		var fb FinishedBooking
-		if err := rows.Scan(&fb.BookingRef, &fb.UserRef, &fb.StartDate, &fb.EndDate, &fb.DistanceMeters, &fb.Lat, &fb.Lon); err != nil {
+		var (
+			fb  FinishedBooking
+			lat sql.NullFloat64
+			lon sql.NullFloat64
+		)
+		if err := rows.Scan(&fb.BookingRef, &fb.UserRef, &fb.StartDate, &fb.EndDate, &fb.DistanceMeters, &lat, &lon); err != nil {
 			return nil, err
+		}
+		if lat.Valid && lon.Valid {
+			fb.Position = &domain.Position{Lat: lat.Float64, Lon: lon.Float64}
 		}
 		bookings = append(bookings, fb)
 	}

--- a/journal/internal/pkg/persistance/postgres/events.go
+++ b/journal/internal/pkg/persistance/postgres/events.go
@@ -23,6 +23,8 @@ type FinishedBooking struct {
 	StartDate      time.Time `json:"start_date"`
 	EndDate        time.Time `json:"end_date"`
 	DistanceMeters int       `json:"distance_meters"`
+	Lat            *float64  `json:"lat,omitempty"`
+	Lon            *float64  `json:"lon,omitempty"`
 }
 
 type EventRepository struct {
@@ -141,8 +143,14 @@ func (r EventRepository) handleBookingEnded(ctx context.Context, payload json.Ra
 		return err
 	}
 
-	q := `INSERT INTO booking_ended_events (fk_user, booking_ref, start_date, end_date, distance_meters) VALUES ($1, $2, $3, $4, $5)`
-	_, err = r.ExecContext(ctx, q, userId, completedBooking.Booking.BookingReference, completedBooking.Booking.StartDate, completedBooking.Booking.EndDate, completedBooking.Distance.Distance())
+	var lat, lon *float64
+	if completedBooking.Position != nil {
+		lat = &completedBooking.Position.Lat
+		lon = &completedBooking.Position.Lon
+	}
+
+	q := `INSERT INTO booking_ended_events (fk_user, booking_ref, start_date, end_date, distance_meters, lat, lon) VALUES ($1, $2, $3, $4, $5, $6, $7)`
+	_, err = r.ExecContext(ctx, q, userId, completedBooking.Booking.BookingReference, completedBooking.Booking.StartDate, completedBooking.Booking.EndDate, completedBooking.Distance.Distance(), lat, lon)
 	return err
 }
 
@@ -154,7 +162,7 @@ type FinishedBookingFilter struct {
 
 func (r EventRepository) GetFinishedBookings(ctx context.Context, f FinishedBookingFilter) ([]FinishedBooking, error) {
 	const query = `
-SELECT b.booking_ref, u.user_ref, b.start_date, b.end_date, b.distance_meters
+SELECT b.booking_ref, u.user_ref, b.start_date, b.end_date, b.distance_meters, b.lat, b.lon
 FROM booking_ended_events b
 INNER JOIN users u ON b.fk_user = u.id
 WHERE ($1::int IS NULL OR EXTRACT(YEAR  FROM b.start_date) = $1)
@@ -171,7 +179,7 @@ ORDER BY b.start_date DESC`
 	bookings := make([]FinishedBooking, 0)
 	for rows.Next() {
 		var fb FinishedBooking
-		if err := rows.Scan(&fb.BookingRef, &fb.UserRef, &fb.StartDate, &fb.EndDate, &fb.DistanceMeters); err != nil {
+		if err := rows.Scan(&fb.BookingRef, &fb.UserRef, &fb.StartDate, &fb.EndDate, &fb.DistanceMeters, &fb.Lat, &fb.Lon); err != nil {
 			return nil, err
 		}
 		bookings = append(bookings, fb)

--- a/journal/internal/pkg/persistance/postgres/events_test.go
+++ b/journal/internal/pkg/persistance/postgres/events_test.go
@@ -1,0 +1,209 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/suite"
+
+	bookingsdomain "github.com/arngrimur/bilcool_monolith/bookings/pkg/domain"
+	"github.com/arngrimur/bilcool_monolith/journal/internal/migrations"
+	brokerpostgres "github.com/arngrimur/bilcool_monolith/message_broker/pkg/postgres"
+	"github.com/arngrimur/bilcool_monolith/testing/testdb"
+
+	_ "github.com/lib/pq"
+)
+
+type eventsTestSuite struct {
+	suite.Suite
+	testdb.SuiteDbIntegration
+	userRef uuid.UUID
+}
+
+func (suite *eventsTestSuite) SetupSuite() {
+	suite.SuiteDbIntegration = testdb.SetupDatabase(suite.T(), migrations.FS, "journal_events_test")
+	suite.userRef = uuid.New()
+}
+
+func (suite *eventsTestSuite) TearDownSuite() {
+	suite.SuiteDbIntegration.TearDown(suite.T())
+}
+
+func (suite *eventsTestSuite) BeforeTest(suiteName, testName string) {
+	_, err := suite.Db.Exec("INSERT INTO users (user_ref, created_at) VALUES ($1, NOW())", suite.userRef)
+	suite.Require().NoError(err)
+}
+
+func (suite *eventsTestSuite) AfterTest(suiteName, testName string) {
+	_, err := suite.Db.Exec("TRUNCATE TABLE inbox, users CASCADE")
+	suite.Require().NoError(err)
+}
+
+func (suite *eventsTestSuite) HandleStats(suiteName string, stats *suite.SuiteInformation) {
+	if !stats.Passed() {
+		buf := strings.Builder{}
+		for _, information := range stats.TestStats {
+			if !information.Passed {
+				fmt.Fprintf(&buf, "Failed %s.%s\n", suiteName, information.TestName)
+			}
+		}
+		suite.Fail(buf.String())
+	}
+}
+
+func TestRunSuiteEvents(t *testing.T) {
+	suite.Run(t, new(eventsTestSuite))
+}
+
+func (suite *eventsTestSuite) TestSaveBookingEndedWithPosition() {
+	repo := NewEventRepository(suite.Db)
+	pos := &bookingsdomain.Position{Lat: 64.128288, Lon: -21.827774}
+
+	cb := bookingsdomain.CompletedBooking{
+		Booking: bookingsdomain.BookingResponse{
+			UserRef:          suite.userRef,
+			BookingReference: uuid.New(),
+			StartDate:        time.Now().Add(-2 * time.Hour),
+			EndDate:          time.Now(),
+		},
+		Distance: bookingsdomain.Distance{StartDistance: 0, EndDistance: 12500},
+		Position: pos,
+	}
+
+	err := repo.SaveBookingEnded(context.Background(), makeBookingEndedMessage(uuid.New(), cb))
+	suite.Require().NoError(err)
+
+	var eventCount int
+	err = suite.Db.QueryRow("SELECT COUNT(*) FROM booking_ended_events").Scan(&eventCount)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, eventCount)
+
+	var lat, lon float64
+	err = suite.Db.QueryRow(`
+		SELECT p.lat, p.lon
+		FROM positions p JOIN booking_ended_events b ON p.fk_booking_ended_event_id = b.id`).Scan(&lat, &lon)
+	suite.Require().NoError(err)
+	suite.Require().InDelta(pos.Lat, lat, 0.000001)
+	suite.Require().InDelta(pos.Lon, lon, 0.000001)
+}
+
+func (suite *eventsTestSuite) TestSaveBookingEndedWithoutPosition() {
+	repo := NewEventRepository(suite.Db)
+
+	cb := bookingsdomain.CompletedBooking{
+		Booking: bookingsdomain.BookingResponse{
+			UserRef:          suite.userRef,
+			BookingReference: uuid.New(),
+			StartDate:        time.Now().Add(-2 * time.Hour),
+			EndDate:          time.Now(),
+		},
+		Distance: bookingsdomain.Distance{StartDistance: 0, EndDistance: 5000},
+	}
+
+	err := repo.SaveBookingEnded(context.Background(), makeBookingEndedMessage(uuid.New(), cb))
+	suite.Require().NoError(err)
+
+	var posCount int
+	err = suite.Db.QueryRow("SELECT COUNT(*) FROM positions").Scan(&posCount)
+	suite.Require().NoError(err)
+	suite.Require().Equal(0, posCount)
+}
+
+func (suite *eventsTestSuite) TestSaveBookingEndedDuplicateIgnored() {
+	repo := NewEventRepository(suite.Db)
+	id := uuid.New()
+
+	cb := bookingsdomain.CompletedBooking{
+		Booking: bookingsdomain.BookingResponse{
+			UserRef:          suite.userRef,
+			BookingReference: uuid.New(),
+			StartDate:        time.Now().Add(-2 * time.Hour),
+			EndDate:          time.Now(),
+		},
+		Distance: bookingsdomain.Distance{StartDistance: 0, EndDistance: 3000},
+	}
+
+	msg := makeBookingEndedMessage(id, cb)
+	err := repo.SaveBookingEnded(context.Background(), msg)
+	suite.Require().NoError(err)
+
+	err = repo.SaveBookingEnded(context.Background(), msg)
+	suite.Require().NoError(err)
+
+	var count int
+	err = suite.Db.QueryRow("SELECT COUNT(*) FROM booking_ended_events").Scan(&count)
+	suite.Require().NoError(err)
+	suite.Require().Equal(1, count)
+}
+
+func (suite *eventsTestSuite) TestGetFinishedBookingsIncludesPosition() {
+	repo := NewEventRepository(suite.Db)
+	pos := &bookingsdomain.Position{Lat: 64.128288, Lon: -21.827774}
+
+	cb := bookingsdomain.CompletedBooking{
+		Booking: bookingsdomain.BookingResponse{
+			UserRef:          suite.userRef,
+			BookingReference: uuid.New(),
+			StartDate:        time.Now().Add(-2 * time.Hour),
+			EndDate:          time.Now(),
+		},
+		Distance: bookingsdomain.Distance{StartDistance: 0, EndDistance: 7500},
+		Position: pos,
+	}
+
+	err := repo.SaveBookingEnded(context.Background(), makeBookingEndedMessage(uuid.New(), cb))
+	suite.Require().NoError(err)
+
+	bookings, err := repo.GetFinishedBookings(context.Background(), FinishedBookingFilter{})
+	suite.Require().NoError(err)
+	suite.Require().Len(bookings, 1)
+	suite.Require().NotNil(bookings[0].Position)
+	suite.Require().InDelta(pos.Lat, bookings[0].Position.Lat, 0.000001)
+	suite.Require().InDelta(pos.Lon, bookings[0].Position.Lon, 0.000001)
+}
+
+func (suite *eventsTestSuite) TestGetFinishedBookingsWithoutPosition() {
+	repo := NewEventRepository(suite.Db)
+
+	cb := bookingsdomain.CompletedBooking{
+		Booking: bookingsdomain.BookingResponse{
+			UserRef:          suite.userRef,
+			BookingReference: uuid.New(),
+			StartDate:        time.Now().Add(-2 * time.Hour),
+			EndDate:          time.Now(),
+		},
+		Distance: bookingsdomain.Distance{StartDistance: 0, EndDistance: 4000},
+	}
+
+	err := repo.SaveBookingEnded(context.Background(), makeBookingEndedMessage(uuid.New(), cb))
+	suite.Require().NoError(err)
+
+	bookings, err := repo.GetFinishedBookings(context.Background(), FinishedBookingFilter{})
+	suite.Require().NoError(err)
+	suite.Require().Len(bookings, 1)
+	suite.Require().Nil(bookings[0].Position)
+}
+
+func makeBookingEndedMessage(id uuid.UUID, cb bookingsdomain.CompletedBooking) brokerpostgres.Message {
+	bytes, _ := json.Marshal(cb)
+	now := time.Now()
+	return brokerpostgres.Message{
+		MessageBody: brokerpostgres.MessageBody{
+			Message: brokerpostgres.Event{
+				EventId:       id,
+				Type:          bookingsdomain.EventBookingEnded,
+				CorrelationId: uuid.New(),
+				Producer:      "bookings",
+				EmittedAt:     &now,
+				Payload:       bytes,
+			},
+		},
+	}
+}


### PR DESCRIPTION
Adds optional lat/lon Position to the end-booking API request body, the
booking.ended event payload (CompletedBooking), the bookings distances
table, and the journal booking_ended_events table. The position
represents where the vehicle was parked when the booking ended.

https://claude.ai/code/session_01Lo8zsQ9pD3k7DATuPyX8UU