### PR TITLE
Add GPS Start/Stop tracking to active booking

### DIFF
--- a/ui/bilcool-ui/src/components/bookings/ActiveBookingTracker.tsx
+++ b/ui/bilcool-ui/src/components/bookings/ActiveBookingTracker.tsx
@@ -1,0 +1,91 @@
+import { useTranslation } from 'react-i18next'
+import { useGpsTracking } from '../../hooks/useGpsTracking'
+import { useEndBooking } from '../../hooks/useBookings'
+import { Button } from '../ui/button'
+import type { BookingResponse } from '../../types/api'
+import { formatTime } from '../../utils/dateUtils'
+import { useSettingsStore } from '../../stores/settingsStore'
+
+interface Props {
+  booking: BookingResponse
+  allBookings: BookingResponse[]
+}
+
+export default function ActiveBookingTracker({ booking, allBookings }: Props) {
+  const { t } = useTranslation('bookings')
+  const language = useSettingsStore((s) => s.language)
+  const endBooking = useEndBooking()
+  const { isTracking, distanceMeters, currentPosition, error, startTracking, stopTracking } =
+    useGpsTracking()
+
+  const now = new Date()
+  const hasOtherActive = allBookings.some(
+    (b) =>
+      b.booking_reference !== booking.booking_reference &&
+      new Date(b.start_date) <= now &&
+      !b.distance,
+  )
+
+  async function handleStop() {
+    stopTracking()
+    await endBooking.mutateAsync({
+      id: booking.booking_reference,
+      body: {
+        start_distance: 0,
+        end_distance: Math.round(distanceMeters),
+        position: currentPosition ?? undefined,
+      },
+    })
+  }
+
+  return (
+    <div className="rounded-lg border-2 border-primary bg-primary/5 p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold text-base">{t('active_booking_title')}</h2>
+        <span className="text-xs font-medium text-primary bg-primary/10 px-2 py-0.5 rounded-full">
+          {t('status_active')}
+        </span>
+      </div>
+
+      <p className="text-sm text-muted-foreground">
+        {formatTime(booking.start_date, language)} – {formatTime(booking.end_date, language)}
+      </p>
+
+      {error && (
+        <p className="text-sm text-destructive">{error}</p>
+      )}
+
+      {isTracking ? (
+        <div className="space-y-3">
+          <div className="text-center py-2">
+            <p className="text-3xl font-bold tabular-nums">
+              {(distanceMeters / 1000).toFixed(2)} km
+            </p>
+            <p className="text-xs text-muted-foreground mt-1">{t('tracking_distance_label')}</p>
+          </div>
+          <Button
+            className="w-full min-h-[52px] text-base"
+            variant="destructive"
+            onClick={handleStop}
+            disabled={endBooking.isPending}
+          >
+            {endBooking.isPending ? '...' : t('stop_tracking')}
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {hasOtherActive ? (
+            <p className="text-sm text-muted-foreground">{t('other_booking_active')}</p>
+          ) : (
+            <Button
+              className="w-full min-h-[52px] text-base"
+              onClick={startTracking}
+            >
+              {t('start_tracking')}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/ui/bilcool-ui/src/hooks/useGpsTracking.ts
+++ b/ui/bilcool-ui/src/hooks/useGpsTracking.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect, useRef } from 'react'
+
+interface TrackingState {
+  isTracking: boolean
+  distanceMeters: number
+  currentPosition: { lat: number; lon: number } | null
+  error: string | null
+}
+
+const LOW_SPEED_THRESHOLD_KMH = 7
+const LOW_SPEED_PAUSE_MS = 5 * 60 * 1000 // 5 minutes
+
+function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
+  const R = 6371000
+  const φ1 = (lat1 * Math.PI) / 180
+  const φ2 = (lat2 * Math.PI) / 180
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180
+  const Δλ = ((lon2 - lon1) * Math.PI) / 180
+  const a = Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+}
+
+export function useGpsTracking() {
+  const [state, setState] = useState<TrackingState>({
+    isTracking: false,
+    distanceMeters: 0,
+    currentPosition: null,
+    error: null,
+  })
+
+  const watchIdRef = useRef<number | null>(null)
+  // last accepted position (lat, lon, timestamp)
+  const lastPosRef = useRef<{ lat: number; lon: number; ts: number } | null>(null)
+  // when speed first dropped below threshold; null means speed is ok
+  const lowSpeedSinceRef = useRef<number | null>(null)
+  // whether accumulation is paused due to sustained low speed
+  const isPausedRef = useRef(false)
+  const distanceRef = useRef(0)
+
+  function startTracking() {
+    if (!navigator.geolocation) {
+      setState((s) => ({ ...s, error: 'GPS not supported on this device' }))
+      return
+    }
+    distanceRef.current = 0
+    lastPosRef.current = null
+    lowSpeedSinceRef.current = null
+    isPausedRef.current = false
+
+    const watchId = navigator.geolocation.watchPosition(
+      (pos) => {
+        const { latitude: lat, longitude: lon, speed } = pos.coords
+        const now = pos.timestamp
+
+        // Derive speed in km/h; fall back to calculating from consecutive points
+        let speedKmh: number
+        if (speed !== null) {
+          speedKmh = speed * 3.6
+        } else if (lastPosRef.current) {
+          const dt = (now - lastPosRef.current.ts) / 1000 // seconds
+          const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
+          speedKmh = dt > 0 ? (dist / dt) * 3.6 : 0
+        } else {
+          speedKmh = 0
+        }
+
+        if (speedKmh >= LOW_SPEED_THRESHOLD_KMH) {
+          // Speed ok: reset low-speed timer and resume accumulation
+          lowSpeedSinceRef.current = null
+          isPausedRef.current = false
+
+          if (lastPosRef.current) {
+            const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
+            distanceRef.current += dist
+          }
+        } else {
+          // Speed below threshold
+          if (lowSpeedSinceRef.current === null) {
+            lowSpeedSinceRef.current = now
+          }
+          const lowSpeedDuration = now - lowSpeedSinceRef.current
+          if (lowSpeedDuration >= LOW_SPEED_PAUSE_MS) {
+            // Sustained low speed: pause accumulation
+            isPausedRef.current = true
+          } else if (!isPausedRef.current && lastPosRef.current) {
+            // Low speed but under the 5-minute threshold: still accumulate
+            const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
+            distanceRef.current += dist
+          }
+        }
+
+        lastPosRef.current = { lat, lon, ts: now }
+
+        setState((s) => ({
+          ...s,
+          distanceMeters: distanceRef.current,
+          currentPosition: { lat, lon },
+          error: null,
+        }))
+      },
+      (err) => setState((s) => ({ ...s, error: err.message })),
+      { enableHighAccuracy: true, maximumAge: 0 },
+    )
+
+    watchIdRef.current = watchId
+    setState((s) => ({ ...s, isTracking: true, distanceMeters: 0, error: null }))
+  }
+
+  function stopTracking() {
+    if (watchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(watchIdRef.current)
+      watchIdRef.current = null
+    }
+    setState((s) => ({ ...s, isTracking: false }))
+  }
+
+  useEffect(() => {
+    return () => {
+      if (watchIdRef.current !== null) {
+        navigator.geolocation.clearWatch(watchIdRef.current)
+      }
+    }
+  }, [])
+
+  return { ...state, startTracking, stopTracking }
+}

--- a/ui/bilcool-ui/src/i18n/locales/en/bookings.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/bookings.json
@@ -36,5 +36,10 @@
   "filter_month": "Month",
   "filter_user": "User",
   "filter_all_users": "All users",
-  "no_bookings": "No bookings found"
+  "no_bookings": "No bookings found",
+  "active_booking_title": "Your Active Booking",
+  "start_tracking": "Start",
+  "stop_tracking": "Stop",
+  "tracking_distance_label": "Distance tracked",
+  "other_booking_active": "Another booking is currently active"
 }

--- a/ui/bilcool-ui/src/i18n/locales/sv/bookings.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/bookings.json
@@ -36,5 +36,10 @@
   "filter_month": "Månad",
   "filter_user": "Användare",
   "filter_all_users": "Alla användare",
-  "no_bookings": "Inga bokningar hittades"
+  "no_bookings": "Inga bokningar hittades",
+  "active_booking_title": "Din aktiva bokning",
+  "start_tracking": "Starta",
+  "stop_tracking": "Stoppa",
+  "tracking_distance_label": "Körd sträcka",
+  "other_booking_active": "En annan bokning är just nu aktiv"
 }

--- a/ui/bilcool-ui/src/pages/BookingsPage.tsx
+++ b/ui/bilcool-ui/src/pages/BookingsPage.tsx
@@ -8,6 +8,7 @@ import { useSettingsStore } from '../stores/settingsStore'
 import type { BookingResponse } from '../types/api'
 import { formatDate, formatTime, formatMonthYear, formatMonthKey } from '../utils/dateUtils'
 import { listFinishedBookings } from '../api/events'
+import ActiveBookingTracker from '../components/bookings/ActiveBookingTracker'
 
 type BookingStatus = 'upcoming' | 'active' | 'overdue'
 
@@ -36,6 +37,10 @@ export default function BookingsPage() {
 
   const { data: allBookings = [] } = useBookings()
   const nonCompleted = allBookings.filter((b) => !b.distance)
+
+  const myActiveBooking = nonCompleted.find(
+    (b) => b.user_ref === userRef && new Date(b.start_date) <= new Date(),
+  )
 
   const summaryParams = { year: selectedYear, user_ref: userFilter }
   const { data: finishedBookingsAll = [] } = useQuery({
@@ -109,6 +114,10 @@ export default function BookingsPage() {
   return (
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">{t('title')}</h1>
+
+      {myActiveBooking && (
+        <ActiveBookingTracker booking={myActiveBooking} allBookings={allBookings} />
+      )}
 
       <section aria-labelledby="summary-heading">
         <h2 id="summary-heading" className="text-lg font-semibold mb-3">{t('summary_title')}</h2>

--- a/ui/bilcool-ui/src/types/api.ts
+++ b/ui/bilcool-ui/src/types/api.ts
@@ -67,6 +67,7 @@ export interface UpdateBookingRequest {
 export interface EndBookingRequest {
   start_distance: number;
   end_distance: number;
+  position?: { lat: number; lon: number };
 }
 
 export interface EventResponse {


### PR DESCRIPTION
Shows an ActiveBookingTracker banner on the Bookings page whenever the
current user has a started, uncompleted booking. The Start button begins
GPS distance accumulation via the Geolocation API; the Stop button ends
the booking and sends the measured distance and final GPS position to
the server.

Speed < 7 km/h sustained for more than 5 minutes pauses accumulation;
it resumes automatically once speed exceeds the threshold again.
Start is disabled while another booking is currently active.

https://claude.ai/code/session_01Lo8zsQ9pD3k7DATuPyX8UU