### PR TITLE
Fix calendar time grid to show full 24-hour range

### DIFF
--- a/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
+++ b/ui/bilcool-ui/src/components/calendar/CalendarView.tsx
@@ -171,8 +171,8 @@ export default function CalendarView({ completedBookingMap }: CalendarViewProps)
           selectable
           selectMirror
           slotDuration="00:15:00"
-          slotMinTime="06:00:00"
-          slotMaxTime="22:00:00"
+          slotMinTime="00:00:00"
+          slotMaxTime="24:00:00"
           allDaySlot={false}
           headerToolbar={{ left: 'prev,next today', center: 'title', right: '' }}
           select={handleSelect}


### PR DESCRIPTION
slotMinTime and slotMaxTime were set to 06:00–22:00, cutting off early
morning and late night hours. Changed to 00:00–24:00 so all hours are
visible.

https://claude.ai/code/session_01PPcWBD4peGWVh9dB8cvehm