### PR TITLE
fix: retroactively exclude low-speed distance when threshold exceeded

### DIFF
--- a/ui/bilcool-ui/src/hooks/useGpsTracking.test.ts
+++ b/ui/bilcool-ui/src/hooks/useGpsTracking.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useGpsTracking } from './useGpsTracking'
+
+const HIGH_SPEED_KMH = 15
+const LOW_SPEED_KMH = 3
+const FIVE_MIN_MS = 5 * 60 * 1000
+
+// Each step moves ~111 metres north, giving a predictable haversine distance
+function makePosition(step: number, speedKmh: number, timestamp: number): GeolocationPosition {
+  return {
+    coords: {
+      latitude: 59.0 + step * 0.001,
+      longitude: 18.0,
+      speed: speedKmh / 3.6, // m/s, as the Geolocation API provides
+      accuracy: 10,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+    },
+    timestamp,
+  } as GeolocationPosition
+}
+
+describe('useGpsTracking – low-speed distance filtering', () => {
+  let sendPosition: (pos: GeolocationPosition) => void
+
+  beforeEach(() => {
+    Object.defineProperty(global.navigator, 'geolocation', {
+      value: {
+        watchPosition: vi.fn((successCb: PositionCallback) => {
+          sendPosition = (pos) => act(() => successCb(pos))
+          return 1
+        }),
+        clearWatch: vi.fn(),
+      },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('accumulates distance while speed stays above 7 km/h', () => {
+    const { result } = renderHook(() => useGpsTracking())
+    act(() => result.current.startTracking())
+
+    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
+    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
+
+    expect(result.current.distanceMeters).toBeGreaterThan(0)
+  })
+
+  it('counts distance accumulated during a brief low-speed window shorter than 5 minutes', () => {
+    const { result } = renderHook(() => useGpsTracking())
+    act(() => result.current.startTracking())
+
+    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
+    const distanceBeforeSlow = result.current.distanceMeters
+
+    // 2-minute slow window — below the 5-minute threshold
+    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
+    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + 2 * 60_000))
+
+    // Recover to high speed
+    sendPosition(makePosition(4, HIGH_SPEED_KMH, 2_000 + 2 * 60_000 + 1_000))
+
+    // The distance covered during the brief slow period must still be included
+    expect(result.current.distanceMeters).toBeGreaterThan(distanceBeforeSlow)
+  })
+
+  it('retroactively removes distance once low speed is sustained for more than 5 minutes', () => {
+    const { result } = renderHook(() => useGpsTracking())
+    act(() => result.current.startTracking())
+
+    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
+    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
+    const distanceBeforeSlow = result.current.distanceMeters
+
+    // Low-speed positions — distance is tentatively added
+    sendPosition(makePosition(3, LOW_SPEED_KMH, 3_000))
+    sendPosition(makePosition(4, LOW_SPEED_KMH, 3_000 + 2 * 60_000))
+    const distanceDuringSlow = result.current.distanceMeters
+    expect(distanceDuringSlow).toBeGreaterThan(distanceBeforeSlow) // tentatively added
+
+    // Cross the 5-minute mark — retroactive removal must trigger
+    sendPosition(makePosition(5, LOW_SPEED_KMH, 3_000 + FIVE_MIN_MS + 1_000))
+
+    expect(result.current.distanceMeters).toBeCloseTo(distanceBeforeSlow, 2)
+    expect(result.current.distanceMeters).toBeLessThan(distanceDuringSlow)
+  })
+
+  it('does not accumulate further distance while paused after the 5-minute threshold', () => {
+    const { result } = renderHook(() => useGpsTracking())
+    act(() => result.current.startTracking())
+
+    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
+
+    // Trigger the 5-minute pause
+    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
+    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 1_000))
+    const distanceAtPause = result.current.distanceMeters
+
+    // Further low-speed positions must not add to the total
+    sendPosition(makePosition(4, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 2_000))
+    sendPosition(makePosition(5, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 3_000))
+
+    expect(result.current.distanceMeters).toBe(distanceAtPause)
+  })
+
+  it('resumes accumulating distance once speed recovers after a sustained low-speed pause', () => {
+    const { result } = renderHook(() => useGpsTracking())
+    act(() => result.current.startTracking())
+
+    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
+    const distanceBeforeSlow = result.current.distanceMeters
+
+    // Sustained low speed — triggers retroactive removal and pause
+    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
+    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 1_000))
+    const distanceAfterPause = result.current.distanceMeters
+    expect(distanceAfterPause).toBeCloseTo(distanceBeforeSlow, 2)
+
+    // Recover to high speed — new movement must count again
+    sendPosition(makePosition(4, HIGH_SPEED_KMH, 2_000 + FIVE_MIN_MS + 2_000))
+    sendPosition(makePosition(5, HIGH_SPEED_KMH, 2_000 + FIVE_MIN_MS + 3_000))
+
+    expect(result.current.distanceMeters).toBeGreaterThan(distanceAfterPause)
+  })
+})

--- a/ui/bilcool-ui/src/hooks/useGpsTracking.ts
+++ b/ui/bilcool-ui/src/hooks/useGpsTracking.ts
@@ -36,6 +36,8 @@ export function useGpsTracking() {
   // whether accumulation is paused due to sustained low speed
   const isPausedRef = useRef(false)
   const distanceRef = useRef(0)
+  // distance accumulated since speed dropped below threshold (may be retroactively removed)
+  const lowSpeedAccumRef = useRef(0)
 
   function startTracking() {
     if (!navigator.geolocation) {
@@ -46,6 +48,7 @@ export function useGpsTracking() {
     lastPosRef.current = null
     lowSpeedSinceRef.current = null
     isPausedRef.current = false
+    lowSpeedAccumRef.current = 0
 
     const watchId = navigator.geolocation.watchPosition(
       (pos) => {
@@ -67,6 +70,7 @@ export function useGpsTracking() {
         if (speedKmh >= LOW_SPEED_THRESHOLD_KMH) {
           // Speed ok: reset low-speed timer and resume accumulation
           lowSpeedSinceRef.current = null
+          lowSpeedAccumRef.current = 0
           isPausedRef.current = false
 
           if (lastPosRef.current) {
@@ -80,12 +84,17 @@ export function useGpsTracking() {
           }
           const lowSpeedDuration = now - lowSpeedSinceRef.current
           if (lowSpeedDuration >= LOW_SPEED_PAUSE_MS) {
-            // Sustained low speed: pause accumulation
-            isPausedRef.current = true
+            if (!isPausedRef.current) {
+              // Threshold just crossed: retroactively remove distance accumulated during low-speed window
+              distanceRef.current = Math.max(0, distanceRef.current - lowSpeedAccumRef.current)
+              lowSpeedAccumRef.current = 0
+              isPausedRef.current = true
+            }
           } else if (!isPausedRef.current && lastPosRef.current) {
-            // Low speed but under the 5-minute threshold: still accumulate
+            // Low speed but under the 5-minute threshold: accumulate tentatively
             const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
             distanceRef.current += dist
+            lowSpeedAccumRef.current += dist
           }
         }
 


### PR DESCRIPTION
Distance accumulated during a low-speed period (<7 km/h) is now
removed from the total when that period is sustained for more than
5 minutes. Previously, the first 5 minutes of low-speed movement
were always counted regardless of total duration.

https://claude.ai/code/session_014rMPxi4eoifLyhQsRqoFch