### PR TITLE
fix: preserve HTTP 401 status when apiFetch throws on unauthorized responses

### DIFF
--- a/ui/bilcool-ui/src/api/client.ts
+++ b/ui/bilcool-ui/src/api/client.ts
@@ -10,7 +10,7 @@ export async function apiFetch<T>(input: RequestInfo, init?: RequestInit): Promi
   if (res.status === 401) {
     localStorage.removeItem('bilcool_token');
     window.dispatchEvent(new Event('auth:logout'));
-    throw new Error('Unauthorized');
+    throw Object.assign(new Error('Unauthorized'), { status: 401 });
   }
   if (!res.ok) {
     const err = await res.json().catch(() => ({ message: 'Unknown error' }));


### PR DESCRIPTION
The apiFetch client was throwing new Error('Unauthorized') without a
status property when the backend returned 401. Both LoginPage and OtpPage
catch blocks check apiErr.status === 401 to show the appropriate error
message (passkey failed / invalid token), but since the thrown error had
no status, they always fell through to the generic error branch instead.

This meant users who entered an expired OTP token saw "something went
wrong" rather than "invalid or expired token", and users whose passkey
assertion failed saw a generic error rather than a passkey-specific one.

https://claude.ai/code/session_01KnZyFXVBGSzdNup8zrzCtT