### PR TITLE
feat(authentication): allow admin to edit user name and email

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -290,6 +290,8 @@ All Go jobs use [Task](https://taskfile.dev) for orchestration and share the ven
 
 ## Key conventions for AI assistants
 
+- **Go version**: This project uses **Go 1.26**.
+- **Pointer to primitive**: Never write helper functions (`strPtr`, `intPtr`, `boolPtr`, etc.) to create pointers to primitive values. Declare a named variable and take its address: `s := "value"; req.Field = &s`.
 - **Service isolation**: Never import a service's `internal/` packages from another service. Only types under `<service>/pkg/` are public.
 - **Persistence interface**: Repository implementations accept `DbActions`, not `*sql.DB`. When adding new repository methods keep this pattern.
 - **CQRS split**: New use cases go into `commands/` (writes) or `queries/` (reads) sub-packages, not directly in `application.go`.

--- a/authentication/internal/pkg/application/application.go
+++ b/authentication/internal/pkg/application/application.go
@@ -21,6 +21,7 @@ type (
 	Commands interface {
 		CreateUser(ctx context.Context, req domain.CreateUserRequest) (extdomain.UserResponse, error)
 		DeleteUser(ctx context.Context, userRef uuid.UUID) error
+		UpdateUser(ctx context.Context, userRef uuid.UUID, req domain.UpdateUserRequest) (extdomain.UserResponse, error)
 		ChangeUserRole(ctx context.Context, callerRef, targetRef uuid.UUID, newRole string) error
 		LoginBegin(ctx context.Context, req domain.LoginBeginRequest) (domain.LoginBeginResponse, error)
 		VerifyToken(ctx context.Context, req domain.VerifyTokenRequest) (domain.VerifyTokenResponse, error)
@@ -42,6 +43,7 @@ type (
 	appCommands struct {
 		commands.CreateUserHandler
 		commands.DeleteUserHandler
+		commands.UpdateUserHandler
 		commands.ChangeUserRoleHandler
 		commands.LoginBeginHandler
 		commands.VerifyTokenHandler
@@ -67,6 +69,7 @@ func New(
 		appCommands: appCommands{
 			CreateUserHandler:     commands.NewCreateUserHandler(users),
 			DeleteUserHandler:     commands.NewDeleteUserHandler(users),
+			UpdateUserHandler:     commands.NewUpdateUserHandler(users),
 			ChangeUserRoleHandler: commands.NewChangeUserRoleHandler(users),
 			LoginBeginHandler:     commands.NewLoginBeginHandler(users, webAuthn),
 			VerifyTokenHandler:    commands.NewVerifyTokenHandler(users, webAuthn),

--- a/authentication/internal/pkg/application/application_test.go
+++ b/authentication/internal/pkg/application/application_test.go
@@ -144,7 +144,9 @@ func TestDeleteUser(t *testing.T) {
 }
 
 func TestUpdateUser(t *testing.T) {
-	strPtr := func(s string) *string { return &s }
+	newname := "newname"
+	newEmail := "new@example.com"
+	takenEmail := "taken@example.com"
 	cases := []struct {
 		name    string
 		req     domain.UpdateUserRequest
@@ -153,31 +155,31 @@ func TestUpdateUser(t *testing.T) {
 	}{
 		{
 			name: "update username only",
-			req:  domain.UpdateUserRequest{Username: strPtr("newname")},
+			req:  domain.UpdateUserRequest{Username: &newname},
 			setup: func(repo *domain.MockUsersRepository) {
-				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Username: strPtr("newname")}).
-					Return(extdomain.UserResponse{Username: "newname", Email: "alice@example.com"}, nil).Times(1)
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Username: &newname}).
+					Return(extdomain.UserResponse{Username: newname, Email: "alice@example.com"}, nil).Times(1)
 			},
 		},
 		{
 			name: "update email only",
-			req:  domain.UpdateUserRequest{Email: strPtr("new@example.com")},
+			req:  domain.UpdateUserRequest{Email: &newEmail},
 			setup: func(repo *domain.MockUsersRepository) {
-				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Email: strPtr("new@example.com")}).
-					Return(extdomain.UserResponse{Username: "alice", Email: "new@example.com"}, nil).Times(1)
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Email: &newEmail}).
+					Return(extdomain.UserResponse{Username: "alice", Email: newEmail}, nil).Times(1)
 			},
 		},
 		{
 			name: "update both",
-			req:  domain.UpdateUserRequest{Username: strPtr("newname"), Email: strPtr("new@example.com")},
+			req:  domain.UpdateUserRequest{Username: &newname, Email: &newEmail},
 			setup: func(repo *domain.MockUsersRepository) {
 				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
-					Return(extdomain.UserResponse{Username: "newname", Email: "new@example.com"}, nil).Times(1)
+					Return(extdomain.UserResponse{Username: newname, Email: newEmail}, nil).Times(1)
 			},
 		},
 		{
 			name: "user not found",
-			req:  domain.UpdateUserRequest{Username: strPtr("newname")},
+			req:  domain.UpdateUserRequest{Username: &newname},
 			setup: func(repo *domain.MockUsersRepository) {
 				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(extdomain.UserResponse{}, domain.ErrUserNotFound).Times(1)
@@ -186,7 +188,7 @@ func TestUpdateUser(t *testing.T) {
 		},
 		{
 			name: "email conflict",
-			req:  domain.UpdateUserRequest{Email: strPtr("taken@example.com")},
+			req:  domain.UpdateUserRequest{Email: &takenEmail},
 			setup: func(repo *domain.MockUsersRepository) {
 				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(extdomain.UserResponse{}, domain.ErrUserAlreadyExists).Times(1)

--- a/authentication/internal/pkg/application/application_test.go
+++ b/authentication/internal/pkg/application/application_test.go
@@ -143,6 +143,80 @@ func TestDeleteUser(t *testing.T) {
 	}
 }
 
+func TestUpdateUser(t *testing.T) {
+	strPtr := func(s string) *string { return &s }
+	cases := []struct {
+		name    string
+		req     domain.UpdateUserRequest
+		setup   func(*domain.MockUsersRepository)
+		wantErr bool
+	}{
+		{
+			name: "update username only",
+			req:  domain.UpdateUserRequest{Username: strPtr("newname")},
+			setup: func(repo *domain.MockUsersRepository) {
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Username: strPtr("newname")}).
+					Return(extdomain.UserResponse{Username: "newname", Email: "alice@example.com"}, nil).Times(1)
+			},
+		},
+		{
+			name: "update email only",
+			req:  domain.UpdateUserRequest{Email: strPtr("new@example.com")},
+			setup: func(repo *domain.MockUsersRepository) {
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), domain.UpdateUserRequest{Email: strPtr("new@example.com")}).
+					Return(extdomain.UserResponse{Username: "alice", Email: "new@example.com"}, nil).Times(1)
+			},
+		},
+		{
+			name: "update both",
+			req:  domain.UpdateUserRequest{Username: strPtr("newname"), Email: strPtr("new@example.com")},
+			setup: func(repo *domain.MockUsersRepository) {
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(extdomain.UserResponse{Username: "newname", Email: "new@example.com"}, nil).Times(1)
+			},
+		},
+		{
+			name: "user not found",
+			req:  domain.UpdateUserRequest{Username: strPtr("newname")},
+			setup: func(repo *domain.MockUsersRepository) {
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(extdomain.UserResponse{}, domain.ErrUserNotFound).Times(1)
+			},
+			wantErr: true,
+		},
+		{
+			name: "email conflict",
+			req:  domain.UpdateUserRequest{Email: strPtr("taken@example.com")},
+			setup: func(repo *domain.MockUsersRepository) {
+				repo.EXPECT().UpdateUser(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(extdomain.UserResponse{}, domain.ErrUserAlreadyExists).Times(1)
+			},
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			repo := domain.NewMockUsersRepository(ctrl)
+			m := mail.NewMockMailSender(ctrl)
+			tc.setup(repo)
+			app := New(repo, m, nil, "secret")
+			resp, err := app.UpdateUser(context.Background(), uuid.New(), tc.req)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.req.Username != nil {
+				require.Equal(t, *tc.req.Username, resp.Username)
+			}
+			if tc.req.Email != nil {
+				require.Equal(t, *tc.req.Email, resp.Email)
+			}
+		})
+	}
+}
+
 func TestGenerateSecurityToken(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		token, err := domain.GenerateSecurityToken()

--- a/authentication/internal/pkg/application/commands/update_user.go
+++ b/authentication/internal/pkg/application/commands/update_user.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/domain"
+	extdomain "github.com/arngrimur/bilcool_monolith/authentication/pkg/domain"
+)
+
+type UpdateUserHandler struct {
+	users *domain.Users
+}
+
+func NewUpdateUserHandler(users *domain.Users) UpdateUserHandler {
+	return UpdateUserHandler{users: users}
+}
+
+func (h UpdateUserHandler) UpdateUser(ctx context.Context, userRef uuid.UUID, req domain.UpdateUserRequest) (extdomain.UserResponse, error) {
+	return h.users.UpdateUser(ctx, userRef, req)
+}

--- a/authentication/internal/pkg/domain/user.go
+++ b/authentication/internal/pkg/domain/user.go
@@ -25,6 +25,11 @@ type CreateUserRequest struct {
 	Email    string `json:"email" validate:"required,email" binding:"required" example:"john@example.com"`
 }
 
+type UpdateUserRequest struct {
+	Username *string `json:"username" example:"johndoe"`
+	Email    *string `json:"email" example:"john@example.com"`
+}
+
 type LoginBeginRequest struct {
 	Email  string `json:"email"  validate:"required,email" binding:"required" example:"john@example.com"`
 	Locale string `json:"locale" example:"sv"`
@@ -165,6 +170,10 @@ func (u *Users) StorePasskey(ctx context.Context, userRef uuid.UUID, passkey Pas
 
 func (u *Users) DeletePasskeys(ctx context.Context, userRef uuid.UUID) error {
 	return u.r.DeletePasskeys(ctx, userRef)
+}
+
+func (u *Users) UpdateUser(ctx context.Context, userRef uuid.UUID, req UpdateUserRequest) (extdomain.UserResponse, error) {
+	return u.r.UpdateUser(ctx, userRef, req)
 }
 
 func (u *Users) ChangeUserRole(ctx context.Context, callerRef, targetRef uuid.UUID, newRole string) error {

--- a/authentication/internal/pkg/domain/user_repository.go
+++ b/authentication/internal/pkg/domain/user_repository.go
@@ -25,4 +25,5 @@ type UsersRepository interface {
 	StorePasskey(ctx context.Context, userRef uuid.UUID, passkey Passkey) error
 	DeletePasskeys(ctx context.Context, userRef uuid.UUID) error
 	ChangeUserRole(ctx context.Context, targetRef uuid.UUID, newRole string) error
+	UpdateUser(ctx context.Context, userRef uuid.UUID, req UpdateUserRequest) (extdomain.UserResponse, error)
 }

--- a/authentication/internal/pkg/persistance/postgresql/users.go
+++ b/authentication/internal/pkg/persistance/postgresql/users.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 
 	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/domain"
 	extdomain "github.com/arngrimur/bilcool_monolith/authentication/pkg/domain"
@@ -294,6 +296,29 @@ func (r UsersRepository) ChangeUserRole(ctx context.Context, targetRef uuid.UUID
 	}
 
 	return tx.Commit()
+}
+
+func (r UsersRepository) UpdateUser(ctx context.Context, userRef uuid.UUID, req domain.UpdateUserRequest) (extdomain.UserResponse, error) {
+	var resp extdomain.UserResponse
+	err := r.QueryRowContext(ctx,
+		`UPDATE users SET
+			username = COALESCE($2, username),
+			email    = COALESCE($3, email)
+		 WHERE user_ref = $1 AND deleted_at IS NULL
+		 RETURNING user_ref, username, email, (SELECT name FROM roles WHERE id = role_id)`,
+		userRef, req.Username, req.Email,
+	).Scan(&resp.UserRef, &resp.Username, &resp.Email, &resp.Role)
+	if errors.Is(err, sql.ErrNoRows) {
+		return extdomain.UserResponse{}, domain.ErrUserNotFound
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == "23505" {
+		return extdomain.UserResponse{}, domain.ErrUserAlreadyExists
+	}
+	if err != nil {
+		return extdomain.UserResponse{}, err
+	}
+	return resp, nil
 }
 
 func (r UsersRepository) StorePasskey(ctx context.Context, userRef uuid.UUID, passkey domain.Passkey) error {

--- a/authentication/internal/pkg/web/router.go
+++ b/authentication/internal/pkg/web/router.go
@@ -49,6 +49,7 @@ func NewRouter(commands application.Commands, queries application.Queries, jwtSe
 	admin.POST("/users", h.createUser)
 	admin.GET("/users", h.listUsers)
 	admin.DELETE("/users/:id", h.deleteUser)
+	admin.PATCH("/users/:id", h.updateUser)
 	admin.PATCH("/users/:id/role", h.changeUserRole)
 
 	return h
@@ -168,6 +169,30 @@ func (h *HttpRouter) getUser(c *gin.Context) {
 		return
 	}
 	resp, err := h.queries.GetUserByRef(c.Request.Context(), id)
+	if err != nil {
+		e := NewHttpError(err)
+		NewError(c, e.Code, e.Message)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *HttpRouter) updateUser(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		NewError(c, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	var req domain.UpdateUserRequest
+	if err := c.ShouldBindBodyWithJSON(&req); err != nil {
+		NewError(c, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Username == nil && req.Email == nil {
+		NewError(c, http.StatusBadRequest, "at least one of username or email must be provided")
+		return
+	}
+	resp, err := h.commands.UpdateUser(c.Request.Context(), id, req)
 	if err != nil {
 		e := NewHttpError(err)
 		NewError(c, e.Code, e.Message)


### PR DESCRIPTION
Adds a PATCH /api/v1/users/:id endpoint (admin-only) that lets an admin
update a user's username, email, or both. The user_ref is never modified.

- Domain: new UpdateUserRequest with optional *string fields for partial updates
- Repository: UpdateUser method using COALESCE so unset fields are unchanged;
  maps sql.ErrNoRows → ErrUserNotFound and pq unique violation → ErrUserAlreadyExists
- Application: UpdateUserHandler command wired into the Commands interface
- Web: PATCH /api/v1/users/:id handler validates that at least one field is present
- Tests: five table-driven cases covering all success and error paths

https://claude.ai/code/session_01BCYBMVNHUPcET9EoXJUdp3