### PR TITLE
feat: allow admins to restore soft-deleted users

### DIFF
--- a/authentication/internal/pkg/application/application.go
+++ b/authentication/internal/pkg/application/application.go
@@ -21,6 +21,7 @@ type (
 	Commands interface {
 		CreateUser(ctx context.Context, req domain.CreateUserRequest) (extdomain.UserResponse, error)
 		DeleteUser(ctx context.Context, userRef uuid.UUID) error
+		RestoreUser(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error)
 		UpdateUser(ctx context.Context, userRef uuid.UUID, req domain.UpdateUserRequest) (extdomain.UserResponse, error)
 		ChangeUserRole(ctx context.Context, callerRef, targetRef uuid.UUID, newRole string) error
 		LoginBegin(ctx context.Context, req domain.LoginBeginRequest) (domain.LoginBeginResponse, error)
@@ -31,6 +32,7 @@ type (
 
 	Queries interface {
 		ListUsers(ctx context.Context) ([]extdomain.UserResponse, error)
+		ListDeletedUsers(ctx context.Context) ([]extdomain.DeletedUserResponse, error)
 		GetUserByRef(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error)
 	}
 )
@@ -43,6 +45,7 @@ type (
 	appCommands struct {
 		commands.CreateUserHandler
 		commands.DeleteUserHandler
+		commands.RestoreUserHandler
 		commands.UpdateUserHandler
 		commands.ChangeUserRoleHandler
 		commands.LoginBeginHandler
@@ -52,6 +55,7 @@ type (
 	}
 	appQueries struct {
 		queries.ListUsersHandler
+		queries.ListDeletedUsersHandler
 		queries.GetUserHandler
 	}
 )
@@ -69,6 +73,7 @@ func New(
 		appCommands: appCommands{
 			CreateUserHandler:     commands.NewCreateUserHandler(users),
 			DeleteUserHandler:     commands.NewDeleteUserHandler(users),
+			RestoreUserHandler:    commands.NewRestoreUserHandler(users),
 			UpdateUserHandler:     commands.NewUpdateUserHandler(users),
 			ChangeUserRoleHandler: commands.NewChangeUserRoleHandler(users),
 			LoginBeginHandler:     commands.NewLoginBeginHandler(users, webAuthn),
@@ -77,8 +82,9 @@ func New(
 			ResetLoginHandler:     commands.NewResetLoginHandler(users),
 		},
 		appQueries: appQueries{
-			ListUsersHandler: queries.NewListUsersHandler(users),
-			GetUserHandler:   queries.NewGetUserHandler(users),
+			ListUsersHandler:        queries.NewListUsersHandler(users),
+			ListDeletedUsersHandler: queries.NewListDeletedUsersHandler(users),
+			GetUserHandler:          queries.NewGetUserHandler(users),
 		},
 	}
 }

--- a/authentication/internal/pkg/application/commands/restore_user.go
+++ b/authentication/internal/pkg/application/commands/restore_user.go
@@ -1,0 +1,22 @@
+package commands
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/domain"
+	extdomain "github.com/arngrimur/bilcool_monolith/authentication/pkg/domain"
+)
+
+type RestoreUserHandler struct {
+	*domain.Users
+}
+
+func NewRestoreUserHandler(users *domain.Users) RestoreUserHandler {
+	return RestoreUserHandler{Users: users}
+}
+
+func (h RestoreUserHandler) RestoreUser(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error) {
+	return h.Users.RestoreUser(ctx, userRef)
+}

--- a/authentication/internal/pkg/application/queries/list_deleted_users.go
+++ b/authentication/internal/pkg/application/queries/list_deleted_users.go
@@ -1,0 +1,20 @@
+package queries
+
+import (
+	"context"
+
+	"github.com/arngrimur/bilcool_monolith/authentication/internal/pkg/domain"
+	extdomain "github.com/arngrimur/bilcool_monolith/authentication/pkg/domain"
+)
+
+type ListDeletedUsersHandler struct {
+	*domain.Users
+}
+
+func NewListDeletedUsersHandler(users *domain.Users) ListDeletedUsersHandler {
+	return ListDeletedUsersHandler{Users: users}
+}
+
+func (h ListDeletedUsersHandler) ListDeletedUsers(ctx context.Context) ([]extdomain.DeletedUserResponse, error) {
+	return h.Users.FindAllDeleted(ctx)
+}

--- a/authentication/internal/pkg/domain/user.go
+++ b/authentication/internal/pkg/domain/user.go
@@ -124,8 +124,16 @@ func (u *Users) DeleteUser(ctx context.Context, userRef uuid.UUID) error {
 	return u.r.DeleteUser(ctx, userRef)
 }
 
+func (u *Users) RestoreUser(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error) {
+	return u.r.RestoreUser(ctx, userRef)
+}
+
 func (u *Users) FindAll(ctx context.Context) ([]extdomain.UserResponse, error) {
 	return u.r.FindAll(ctx)
+}
+
+func (u *Users) FindAllDeleted(ctx context.Context) ([]extdomain.DeletedUserResponse, error) {
+	return u.r.FindAllDeleted(ctx)
 }
 
 func (u *Users) FindByEmail(ctx context.Context, email string) (extdomain.UserResponse, error) {

--- a/authentication/internal/pkg/domain/user_repository.go
+++ b/authentication/internal/pkg/domain/user_repository.go
@@ -13,7 +13,9 @@ import (
 type UsersRepository interface {
 	CreateUser(ctx context.Context, req CreateUserRequest) (extdomain.UserResponse, error)
 	DeleteUser(ctx context.Context, userRef uuid.UUID) error
+	RestoreUser(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error)
 	FindAll(ctx context.Context) ([]extdomain.UserResponse, error)
+	FindAllDeleted(ctx context.Context) ([]extdomain.DeletedUserResponse, error)
 	FindByEmail(ctx context.Context, email string) (extdomain.UserResponse, error)
 	FindByRef(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error)
 	CreateSecurityToken(ctx context.Context, userRef uuid.UUID, token string, expiresAt time.Time) error

--- a/authentication/internal/pkg/persistance/postgresql/users.go
+++ b/authentication/internal/pkg/persistance/postgresql/users.go
@@ -126,6 +126,72 @@ func (r UsersRepository) DeleteUser(ctx context.Context, userRef uuid.UUID) erro
 	return tx.Commit()
 }
 
+func (r UsersRepository) RestoreUser(ctx context.Context, userRef uuid.UUID) (extdomain.UserResponse, error) {
+	local_r, tx, err := r.createTransaction(ctx)
+	if err != nil {
+		return extdomain.UserResponse{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var resp extdomain.UserResponse
+	err = local_r.QueryRowContext(ctx,
+		`UPDATE users SET deleted_at = NULL WHERE user_ref = $1 AND deleted_at IS NOT NULL
+		 RETURNING user_ref, username, email, (SELECT name FROM roles WHERE id = role_id)`,
+		userRef,
+	).Scan(&resp.UserRef, &resp.Username, &resp.Email, &resp.Role)
+	if err == sql.ErrNoRows {
+		return extdomain.UserResponse{}, domain.ErrUserNotFound
+	}
+	if err != nil {
+		return extdomain.UserResponse{}, err
+	}
+
+	payload, err := json.Marshal(resp)
+	if err != nil {
+		return extdomain.UserResponse{}, err
+	}
+	err = outbox.Insert(ctx, tx, outbox.Event{
+		EventId:       uuid.New(),
+		Type:          extdomain.EventUserRestored,
+		CorrelationId: uuid.New(),
+		Producer:      extdomain.EventProducer,
+		Payload:       payload,
+	})
+	if err != nil {
+		return extdomain.UserResponse{}, err
+	}
+
+	return resp, tx.Commit()
+}
+
+func (r UsersRepository) FindAllDeleted(ctx context.Context) ([]extdomain.DeletedUserResponse, error) {
+	rows, err := r.QueryContext(ctx,
+		`SELECT u.user_ref, u.username, u.email, r.name, u.deleted_at
+		 FROM users u JOIN roles r ON r.id = u.role_id
+		 WHERE u.deleted_at IS NOT NULL
+		 ORDER BY u.deleted_at DESC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	users := make([]extdomain.DeletedUserResponse, 0)
+	for rows.Next() {
+		var u extdomain.DeletedUserResponse
+		var deletedAt time.Time
+		if err := rows.Scan(&u.UserRef, &u.Username, &u.Email, &u.Role, &deletedAt); err != nil {
+			return nil, err
+		}
+		u.DeletedAt = deletedAt.UTC().Format(time.RFC3339)
+		users = append(users, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return users, nil
+}
+
 func (r UsersRepository) FindAll(ctx context.Context) ([]extdomain.UserResponse, error) {
 	rows, err := r.QueryContext(ctx,
 		`SELECT u.user_ref, u.username, u.email, r.name

--- a/authentication/internal/pkg/web/router.go
+++ b/authentication/internal/pkg/web/router.go
@@ -48,7 +48,9 @@ func NewRouter(commands application.Commands, queries application.Queries, jwtSe
 	admin := h.router.Group("/api/v1", h.jwtMiddleware(), h.requireAdmin())
 	admin.POST("/users", h.createUser)
 	admin.GET("/users", h.listUsers)
+	admin.GET("/users/deleted", h.listDeletedUsers)
 	admin.DELETE("/users/:id", h.deleteUser)
+	admin.POST("/users/:id/restore", h.restoreUser)
 	admin.PATCH("/users/:id", h.updateUser)
 	admin.PATCH("/users/:id/role", h.changeUserRole)
 
@@ -154,6 +156,31 @@ func (h *HttpRouter) deleteUser(c *gin.Context) {
 
 func (h *HttpRouter) listUsers(c *gin.Context) {
 	resp, err := h.queries.ListUsers(c.Request.Context())
+	if err != nil {
+		e := NewHttpError(err)
+		NewError(c, e.Code, e.Message)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *HttpRouter) listDeletedUsers(c *gin.Context) {
+	resp, err := h.queries.ListDeletedUsers(c.Request.Context())
+	if err != nil {
+		e := NewHttpError(err)
+		NewError(c, e.Code, e.Message)
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+func (h *HttpRouter) restoreUser(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		NewError(c, http.StatusBadRequest, "invalid user id")
+		return
+	}
+	resp, err := h.commands.RestoreUser(c.Request.Context(), id)
 	if err != nil {
 		e := NewHttpError(err)
 		NewError(c, e.Code, e.Message)

--- a/authentication/pkg/domain/user.go
+++ b/authentication/pkg/domain/user.go
@@ -1,6 +1,8 @@
 package domain
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+)
 
 type UserResponse struct {
 	UserRef  uuid.UUID `json:"user_ref" example:"550e8400-e29b-41d4-a716-446655440000"`
@@ -9,6 +11,15 @@ type UserResponse struct {
 	Role     string    `json:"role" example:"user"`
 }
 
+type DeletedUserResponse struct {
+	UserRef   uuid.UUID `json:"user_ref" example:"550e8400-e29b-41d4-a716-446655440000"`
+	Username  string    `json:"username" example:"johndoe"`
+	Email     string    `json:"email" example:"john@example.com"`
+	Role      string    `json:"role" example:"user"`
+	DeletedAt string    `json:"deleted_at" example:"2026-05-04T12:00:00Z"`
+}
+
 const EventProducer string = "authentication"
 const EventUserCreated string = "user.created"
 const EventUserDeleted string = "user.deleted"
+const EventUserRestored string = "user.restored"

--- a/ui/bilcool-ui/src/api/auth.ts
+++ b/ui/bilcool-ui/src/api/auth.ts
@@ -9,6 +9,7 @@ import type {
   LoginCompleteResponse,
   CreateUserRequest,
   UserResponse,
+  DeletedUserResponse,
   ChangeUserRoleRequest,
 } from '../types/api';
 
@@ -40,3 +41,9 @@ export const deleteUser = (id: string) =>
 
 export const changeUserRole = (id: string, body: ChangeUserRoleRequest) =>
   apiFetch<void>(`${BASE}/users/${id}/role`, { method: 'PATCH', body: JSON.stringify(body) });
+
+export const listDeletedUsers = () =>
+  apiFetch<DeletedUserResponse[]>(`${BASE}/users/deleted`);
+
+export const restoreUser = (id: string) =>
+  apiFetch<UserResponse>(`${BASE}/users/${id}/restore`, { method: 'POST' });

--- a/ui/bilcool-ui/src/hooks/useUsers.ts
+++ b/ui/bilcool-ui/src/hooks/useUsers.ts
@@ -1,5 +1,5 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getUser, listUsers, createUser, deleteUser, changeUserRole } from '../api/auth'
+import { getUser, listUsers, listDeletedUsers, createUser, deleteUser, changeUserRole, restoreUser } from '../api/auth'
 import type { CreateUserRequest, ChangeUserRoleRequest } from '../types/api'
 
 export function useAllUsers() {
@@ -31,12 +31,31 @@ export function useCreateUser() {
   })
 }
 
+export function useDeletedUsers() {
+  return useQuery({
+    queryKey: ['users', 'deleted'],
+    queryFn: async () => (await listDeletedUsers()) ?? [],
+    staleTime: 5 * 60_000,
+  })
+}
+
 export function useDeleteUser() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => deleteUser(id),
     onSuccess: (_data, id) => {
       queryClient.removeQueries({ queryKey: ['user', id] })
+      queryClient.invalidateQueries({ queryKey: ['users'] })
+    },
+  })
+}
+
+export function useRestoreUser() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: (id: string) => restoreUser(id),
+    onSuccess: (user) => {
+      queryClient.setQueryData(['user', user.user_ref], user)
       queryClient.invalidateQueries({ queryKey: ['users'] })
     },
   })

--- a/ui/bilcool-ui/src/i18n/locales/en/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/common.json
@@ -54,7 +54,12 @@
     "no_users": "No users found",
     "promote_to_admin": "Make admin",
     "demote_to_user": "Make user",
-    "role_changed": "Role updated"
+    "role_changed": "Role updated",
+    "deleted_users_title": "Deleted Users",
+    "no_deleted_users": "No deleted users",
+    "col_deleted_at": "Deleted at",
+    "restore_user": "Restore",
+    "user_restored": "User {{username}} restored"
   },
   "errors": { "unexpected": "An unexpected error occurred" }
 }

--- a/ui/bilcool-ui/src/i18n/locales/sv/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/common.json
@@ -54,7 +54,12 @@
     "no_users": "Inga användare hittades",
     "promote_to_admin": "Gör till admin",
     "demote_to_user": "Gör till användare",
-    "role_changed": "Roll uppdaterad"
+    "role_changed": "Roll uppdaterad",
+    "deleted_users_title": "Raderade användare",
+    "no_deleted_users": "Inga raderade användare",
+    "col_deleted_at": "Raderad den",
+    "restore_user": "Återställ",
+    "user_restored": "Användare {{username}} återställd"
   },
   "errors": { "unexpected": "Ett oväntat fel uppstod" }
 }

--- a/ui/bilcool-ui/src/pages/AdminUsersPage.tsx
+++ b/ui/bilcool-ui/src/pages/AdminUsersPage.tsx
@@ -2,7 +2,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useTranslation } from 'react-i18next'
-import { useAllUsers, useCreateUser, useDeleteUser, useChangeUserRole } from '../hooks/useUsers'
+import { useAllUsers, useDeletedUsers, useCreateUser, useDeleteUser, useChangeUserRole, useRestoreUser } from '../hooks/useUsers'
 import { useAuthStore } from '../stores/authStore'
 import { toast } from '../components/ui/use-toast'
 import { Button } from '../components/ui/button'
@@ -24,9 +24,11 @@ export default function AdminUsersPage() {
   const currentEmail = useAuthStore((s) => s.email)
 
   const { data: allUsers = [] } = useAllUsers()
+  const { data: deletedUsers = [] } = useDeletedUsers()
 
   const createUser = useCreateUser()
   const deleteUser = useDeleteUser()
+  const restoreUser = useRestoreUser()
   const changeUserRole = useChangeUserRole()
 
   const {
@@ -45,6 +47,11 @@ export default function AdminUsersPage() {
   async function handleDelete(id: string) {
     await deleteUser.mutateAsync(id)
     toast({ title: t('admin.user_deleted') })
+  }
+
+  async function handleRestore(id: string, username: string) {
+    await restoreUser.mutateAsync(id)
+    toast({ title: t('admin.user_restored', { username }) })
   }
 
   async function handleRoleChange(id: string, newRole: 'admin' | 'user') {
@@ -170,6 +177,49 @@ export default function AdminUsersPage() {
                         className="min-h-[44px]"
                       >
                         {t('admin.delete_user')}
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+
+      <section aria-labelledby="deleted-users-heading">
+        <h2 id="deleted-users-heading" className="text-lg font-semibold mb-4">{t('admin.deleted_users_title')}</h2>
+
+        {deletedUsers.length === 0 ? (
+          <p className="text-sm text-muted-foreground">{t('admin.no_deleted_users')}</p>
+        ) : (
+          <div className="rounded-lg border overflow-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b bg-muted/50">
+                  <th className="px-4 py-3 text-left font-medium">{t('admin.col_username')}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t('admin.col_email')}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t('admin.col_role')}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t('admin.col_deleted_at')}</th>
+                  <th className="px-4 py-3 text-left font-medium">{t('admin.col_actions')}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {deletedUsers.map((user) => (
+                  <tr key={user.user_ref} className="border-b last:border-0 text-muted-foreground">
+                    <td className="px-4 py-3">{user.username}</td>
+                    <td className="px-4 py-3">{user.email}</td>
+                    <td className="px-4 py-3">{user.role}</td>
+                    <td className="px-4 py-3">{new Date(user.deleted_at).toLocaleString()}</td>
+                    <td className="px-4 py-3">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => handleRestore(user.user_ref, user.username)}
+                        disabled={restoreUser.isPending}
+                        className="min-h-[44px]"
+                      >
+                        {t('admin.restore_user')}
                       </Button>
                     </td>
                   </tr>

--- a/ui/bilcool-ui/src/types/api.ts
+++ b/ui/bilcool-ui/src/types/api.ts
@@ -14,6 +14,14 @@ export interface UserResponse {
   role: 'admin' | 'user';
 }
 
+export interface DeletedUserResponse {
+  user_ref: string;
+  username: string;
+  email: string;
+  role: 'admin' | 'user';
+  deleted_at: string;
+}
+
 export interface LoginBeginRequest {
   email: string;
 }


### PR DESCRIPTION
Adds a full restore-user flow: admins can now view deleted users in a
separate table on the Users admin page and click Restore to undelete them.

Backend:
- Add RestoreUser/FindAllDeleted to UsersRepository interface and Users service
- Implement both in the PostgreSQL layer (clears deleted_at, publishes
  user.restored outbox event; FindAllDeleted queries WHERE deleted_at IS NOT NULL)
- Add DeletedUserResponse type (with deleted_at field) and EventUserRestored
  constant to the public domain package
- Add RestoreUserHandler command and ListDeletedUsersHandler query
- Wire both into application.go Commands/Queries interfaces and Application struct
- Expose GET /api/v1/users/deleted and POST /api/v1/users/:id/restore (admin-only)

Frontend:
- Add DeletedUserResponse type to api.ts
- Add listDeletedUsers and restoreUser API functions
- Add useDeletedUsers and useRestoreUser React Query hooks
- Add i18n keys in en/sv for deleted users table and restore action
- AdminUsersPage: render deleted users section below active users table,
  showing username, email, role, deletion timestamp, and a Restore button

https://claude.ai/code/session_013QVW7rbd6AzeS3WneF9t2H