### PR TITLE
feat(ui): add edit user button on admin users page

### DIFF
--- a/ui/bilcool-ui/src/api/auth.ts
+++ b/ui/bilcool-ui/src/api/auth.ts
@@ -11,6 +11,7 @@ import type {
   UserResponse,
   DeletedUserResponse,
   ChangeUserRoleRequest,
+  UpdateUserRequest,
 } from '../types/api';
 
 const BASE = '/api/v1';
@@ -41,6 +42,9 @@ export const deleteUser = (id: string) =>
 
 export const changeUserRole = (id: string, body: ChangeUserRoleRequest) =>
   apiFetch<void>(`${BASE}/users/${id}/role`, { method: 'PATCH', body: JSON.stringify(body) });
+
+export const updateUser = (id: string, body: UpdateUserRequest) =>
+  apiFetch<UserResponse>(`${BASE}/users/${id}`, { method: 'PATCH', body: JSON.stringify(body) });
 
 export const listDeletedUsers = () =>
   apiFetch<DeletedUserResponse[]>(`${BASE}/users/deleted`);

--- a/ui/bilcool-ui/src/hooks/useUsers.ts
+++ b/ui/bilcool-ui/src/hooks/useUsers.ts
@@ -1,6 +1,6 @@
 import { useQuery, useQueries, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getUser, listUsers, listDeletedUsers, createUser, deleteUser, changeUserRole, restoreUser } from '../api/auth'
-import type { CreateUserRequest, ChangeUserRoleRequest } from '../types/api'
+import { getUser, listUsers, listDeletedUsers, createUser, deleteUser, changeUserRole, restoreUser, updateUser } from '../api/auth'
+import type { CreateUserRequest, ChangeUserRoleRequest, UpdateUserRequest } from '../types/api'
 
 export function useAllUsers() {
   return useQuery({
@@ -54,6 +54,17 @@ export function useRestoreUser() {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: (id: string) => restoreUser(id),
+    onSuccess: (user) => {
+      queryClient.setQueryData(['user', user.user_ref], user)
+      queryClient.invalidateQueries({ queryKey: ['users'] })
+    },
+  })
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ id, ...body }: { id: string } & UpdateUserRequest) => updateUser(id, body),
     onSuccess: (user) => {
       queryClient.setQueryData(['user', user.user_ref], user)
       queryClient.invalidateQueries({ queryKey: ['users'] })

--- a/ui/bilcool-ui/src/i18n/locales/en/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/common.json
@@ -59,7 +59,11 @@
     "no_deleted_users": "No deleted users",
     "col_deleted_at": "Deleted at",
     "restore_user": "Restore",
-    "user_restored": "User {{username}} restored"
+    "user_restored": "User {{username}} restored",
+    "edit_user": "Edit",
+    "save_user": "Save",
+    "cancel": "Cancel",
+    "user_updated": "User {{username}} updated"
   },
   "errors": { "unexpected": "An unexpected error occurred" }
 }

--- a/ui/bilcool-ui/src/i18n/locales/sv/common.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/common.json
@@ -59,7 +59,11 @@
     "no_deleted_users": "Inga raderade användare",
     "col_deleted_at": "Raderad den",
     "restore_user": "Återställ",
-    "user_restored": "Användare {{username}} återställd"
+    "user_restored": "Användare {{username}} återställd",
+    "edit_user": "Redigera",
+    "save_user": "Spara",
+    "cancel": "Avbryt",
+    "user_updated": "Användare {{username}} uppdaterad"
   },
   "errors": { "unexpected": "Ett oväntat fel uppstod" }
 }

--- a/ui/bilcool-ui/src/pages/AdminUsersPage.tsx
+++ b/ui/bilcool-ui/src/pages/AdminUsersPage.tsx
@@ -1,8 +1,9 @@
+import { useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useTranslation } from 'react-i18next'
-import { useAllUsers, useDeletedUsers, useCreateUser, useDeleteUser, useChangeUserRole, useRestoreUser } from '../hooks/useUsers'
+import { useAllUsers, useDeletedUsers, useCreateUser, useDeleteUser, useChangeUserRole, useRestoreUser, useUpdateUser } from '../hooks/useUsers'
 import { useAuthStore } from '../stores/authStore'
 import { toast } from '../components/ui/use-toast'
 import { Button } from '../components/ui/button'
@@ -15,6 +16,13 @@ const createSchema = z.object({
 })
 
 type CreateFormValues = z.infer<typeof createSchema>
+
+const editSchema = z.object({
+  username: z.string().min(1),
+  email: z.string().email(),
+})
+
+type EditFormValues = z.infer<typeof editSchema>
 
 export default function AdminUsersPage() {
   const { t } = useTranslation('common')
@@ -30,6 +38,9 @@ export default function AdminUsersPage() {
   const deleteUser = useDeleteUser()
   const restoreUser = useRestoreUser()
   const changeUserRole = useChangeUserRole()
+  const updateUser = useUpdateUser()
+
+  const [editingId, setEditingId] = useState<string | null>(null)
 
   const {
     register,
@@ -37,6 +48,13 @@ export default function AdminUsersPage() {
     reset,
     formState: { errors, isSubmitting },
   } = useForm<CreateFormValues>({ resolver: zodResolver(createSchema) })
+
+  const {
+    register: registerEdit,
+    handleSubmit: handleSubmitEdit,
+    reset: resetEdit,
+    formState: { errors: editErrors, isSubmitting: isEditSubmitting },
+  } = useForm<EditFormValues>({ resolver: zodResolver(editSchema) })
 
   async function onSubmit(data: CreateFormValues) {
     const user = await createUser.mutateAsync(data)
@@ -57,6 +75,21 @@ export default function AdminUsersPage() {
   async function handleRoleChange(id: string, newRole: 'admin' | 'user') {
     await changeUserRole.mutateAsync({ id, role: newRole })
     toast({ title: t('admin.role_changed') })
+  }
+
+  function startEdit(user: { user_ref: string; username: string; email: string }) {
+    setEditingId(user.user_ref)
+    resetEdit({ username: user.username, email: user.email })
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+  }
+
+  async function onEditSubmit(data: EditFormValues) {
+    const user = await updateUser.mutateAsync({ id: editingId!, ...data })
+    toast({ title: t('admin.user_updated', { username: user.username }) })
+    setEditingId(null)
   }
 
   if (role !== 'admin') {
@@ -153,34 +186,94 @@ export default function AdminUsersPage() {
                 </tr>
               </thead>
               <tbody>
-                {allUsers.map((user) => (
-                  <tr key={user.user_ref} className="border-b last:border-0">
-                    <td className="px-4 py-3">{user.username}</td>
-                    <td className="px-4 py-3">{user.email}</td>
-                    <td className="px-4 py-3">{user.role}</td>
-                    <td className="px-4 py-3 flex gap-2">
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => handleRoleChange(user.user_ref, user.role === 'admin' ? 'user' : 'admin')}
-                        disabled={user.user_ref === currentUserRef || changeUserRole.isPending}
-                        className="min-h-[44px]"
-                      >
-                        {user.role === 'admin' ? t('admin.demote_to_user') : t('admin.promote_to_admin')}
-                      </Button>
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => handleDelete(user.user_ref)}
-                        disabled={user.user_ref === currentUserRef || deleteUser.isPending}
-                        aria-label={t('admin.delete_confirm', { username: user.username })}
-                        className="min-h-[44px]"
-                      >
-                        {t('admin.delete_user')}
-                      </Button>
-                    </td>
-                  </tr>
-                ))}
+                {allUsers.map((user) =>
+                  editingId === user.user_ref ? (
+                    <tr key={user.user_ref} className="border-b last:border-0">
+                      <td className="px-4 py-2">
+                        <Input
+                          {...registerEdit('username')}
+                          aria-describedby={editErrors.username ? `edit-username-error-${user.user_ref}` : undefined}
+                          disabled={isEditSubmitting}
+                          className="h-9"
+                        />
+                        {editErrors.username && (
+                          <p id={`edit-username-error-${user.user_ref}`} className="text-xs text-destructive mt-1" role="alert">
+                            {editErrors.username.message}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">
+                        <Input
+                          type="email"
+                          {...registerEdit('email')}
+                          aria-describedby={editErrors.email ? `edit-email-error-${user.user_ref}` : undefined}
+                          disabled={isEditSubmitting}
+                          className="h-9"
+                        />
+                        {editErrors.email && (
+                          <p id={`edit-email-error-${user.user_ref}`} className="text-xs text-destructive mt-1" role="alert">
+                            {editErrors.email.message}
+                          </p>
+                        )}
+                      </td>
+                      <td className="px-4 py-2">{user.role}</td>
+                      <td className="px-4 py-2 flex gap-2">
+                        <Button
+                          size="sm"
+                          onClick={handleSubmitEdit(onEditSubmit)}
+                          disabled={isEditSubmitting}
+                          className="min-h-[44px]"
+                        >
+                          {isEditSubmitting ? '...' : t('admin.save_user')}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={cancelEdit}
+                          disabled={isEditSubmitting}
+                          className="min-h-[44px]"
+                        >
+                          {t('admin.cancel')}
+                        </Button>
+                      </td>
+                    </tr>
+                  ) : (
+                    <tr key={user.user_ref} className="border-b last:border-0">
+                      <td className="px-4 py-3">{user.username}</td>
+                      <td className="px-4 py-3">{user.email}</td>
+                      <td className="px-4 py-3">{user.role}</td>
+                      <td className="px-4 py-3 flex gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => startEdit(user)}
+                          className="min-h-[44px]"
+                        >
+                          {t('admin.edit_user')}
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => handleRoleChange(user.user_ref, user.role === 'admin' ? 'user' : 'admin')}
+                          disabled={user.user_ref === currentUserRef || changeUserRole.isPending}
+                          className="min-h-[44px]"
+                        >
+                          {user.role === 'admin' ? t('admin.demote_to_user') : t('admin.promote_to_admin')}
+                        </Button>
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => handleDelete(user.user_ref)}
+                          disabled={user.user_ref === currentUserRef || deleteUser.isPending}
+                          aria-label={t('admin.delete_confirm', { username: user.username })}
+                          className="min-h-[44px]"
+                        >
+                          {t('admin.delete_user')}
+                        </Button>
+                      </td>
+                    </tr>
+                  )
+                )}
               </tbody>
             </table>
           </div>

--- a/ui/bilcool-ui/src/types/api.ts
+++ b/ui/bilcool-ui/src/types/api.ts
@@ -7,6 +7,11 @@ export interface ChangeUserRoleRequest {
   role: 'admin' | 'user';
 }
 
+export interface UpdateUserRequest {
+  username?: string;
+  email?: string;
+}
+
 export interface UserResponse {
   user_ref: string;
   username: string;


### PR DESCRIPTION
Wires up the existing PATCH /api/v1/users/:id backend endpoint with
inline row editing — clicking Edit turns the username/email cells into
validated inputs; Save calls the API, Cancel restores the read view.

https://claude.ai/code/session_019xWGatYYQgYXbCntHxbeSZ