### PR TITLE
Replace client-side Haversine with server-side Mapbox road distance

### DIFF
--- a/bookings/cmd/lambda/http/main.go
+++ b/bookings/cmd/lambda/http/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/arngrimur/bilcool-lib/pkg/logging"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/application"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/config"
+	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/infrastructure/mapbox"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/persistance/postgresql"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/web"
 	coutbox "github.com/arngrimur/bilcool_monolith/message_broker/pkg/postgres"
@@ -35,7 +36,8 @@ func main() {
 		log.Fatal().Err(err).Msg("error creating outbox table")
 	}
 	repo := postgresql.NewBookingsRepository(db)
-	app := application.New(repo)
+	mapboxClient := mapbox.NewClient(config.MapboxAccessToken())
+	app := application.New(repo, mapboxClient)
 	ginLambda := ginadapter.NewV2(web.NewRouter(app.GetBookingsHandler, app.UpdateBookingsHandler).Engine())
 
 	lambda.Start(func(ctx context.Context, req events.APIGatewayV2HTTPRequest) (events.APIGatewayV2HTTPResponse, error) {

--- a/bookings/cmd/main.go
+++ b/bookings/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/config"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/event_dispatcher"
 	bookinginbox "github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/inbox"
+	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/infrastructure/mapbox"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/persistance/postgresql"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/web"
 	soutbox "github.com/arngrimur/bilcool_monolith/message_broker/pkg/domain"
@@ -98,7 +99,8 @@ func main() {
 	worker.Start(ctx)
 	defer worker.Stop()
 
-	app := application.New(repo)
+	mapboxClient := mapbox.NewClient(config.MapboxAccessToken())
+	app := application.New(repo, mapboxClient)
 	webService := web.NewRouter(app.GetBookingsHandler, app.UpdateBookingsHandler)
 	err = webService.StartRouter(":8080")
 	if err != nil {

--- a/bookings/go.mod
+++ b/bookings/go.mod
@@ -3,12 +3,16 @@ module github.com/arngrimur/bilcool_monolith/bookings
 go 1.26.0
 
 require (
+	github.com/amacneil/dbmate/v2 v2.32.0
 	github.com/arngrimur/bilcool_monolith v0.1.0
-	github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260416092020-364bd8b53ab3
+	github.com/arngrimur/bilcool_monolith/authentication v0.0.0-20260416092020-364bd8b53ab3
+	github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260514201903-347b38328692
 	github.com/arngrimur/bilcool_monolith/testing v0.0.0-20260402112002-df5a2cfef02b
+	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.15
+	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2
 	github.com/gin-gonic/gin v1.12.0
 	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.3
@@ -25,9 +29,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/amacneil/dbmate/v2 v2.32.0 // indirect
-	github.com/arngrimur/bilcool_monolith/authentication v0.0.0-20260416092020-364bd8b53ab3 // indirect
-	github.com/aws/aws-lambda-go v1.54.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
@@ -41,7 +42,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.10 // indirect
 	github.com/aws/smithy-go v1.24.3 // indirect
-	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect

--- a/bookings/go.sum
+++ b/bookings/go.sum
@@ -27,6 +27,8 @@ github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260402112002-df5a2
 github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260402112002-df5a2cfef02b/go.mod h1:zVnjQkGN9+M47joJ+MEQepSnCml19uieHmnUnvBjEJQ=
 github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260416092020-364bd8b53ab3 h1:oVSjKTvcD2c0W+bRSGq+YVVIprFdzRmBeay2nKw80W4=
 github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260416092020-364bd8b53ab3/go.mod h1:/gWcdy2RdcOdH/b6VKOCqLwd9xVDb/eb4eWTh7Yos/E=
+github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260514201903-347b38328692 h1:rdrU1XL+GWLMWgmWgQmtEoR/iVoDMy0Yuvsk1u8QGcg=
+github.com/arngrimur/bilcool_monolith/message_broker v0.0.0-20260514201903-347b38328692/go.mod h1:/gWcdy2RdcOdH/b6VKOCqLwd9xVDb/eb4eWTh7Yos/E=
 github.com/arngrimur/bilcool_monolith/testing v0.0.0-20260324161225-100b97514df9 h1:+Nefg3oRgIRlDqB7wUsv7jojNa0eirln/OH4J2QmmIQ=
 github.com/arngrimur/bilcool_monolith/testing v0.0.0-20260324161225-100b97514df9/go.mod h1:FG8tzb1NN20Rp3iS1y8cu82hK0+lCgSnwqNFidiMUOA=
 github.com/arngrimur/bilcool_monolith/testing v0.0.0-20260402112002-df5a2cfef02b h1:uDN/3k1cbWRA94feA3Fgd5tsGJXfkzzWJoH9c6Tm+g0=

--- a/bookings/internal/migrations/20260518000000_add_gps_track_points.sql
+++ b/bookings/internal/migrations/20260518000000_add_gps_track_points.sql
@@ -1,0 +1,12 @@
+-- migrate:up
+CREATE TABLE gps_track_points (
+    id            SERIAL PRIMARY KEY,
+    fk_booking_id INT NOT NULL REFERENCES bookings(id),
+    lat           DOUBLE PRECISION NOT NULL,
+    lon           DOUBLE PRECISION NOT NULL,
+    recorded_at   TIMESTAMPTZ NOT NULL,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- migrate:down
+DROP TABLE gps_track_points;

--- a/bookings/internal/pkg/application/application.go
+++ b/bookings/internal/pkg/application/application.go
@@ -22,6 +22,7 @@ type (
 		EndBooking(ctx context.Context, request domain.EndBookingRequest) error
 		PauseBooking(ctx context.Context, request domain.PauseBookingRequest) error
 		ResumeBooking(ctx context.Context, request domain.BookingRequest) (domain.PauseBookingResponse, error)
+		AddTrackPoints(ctx context.Context, request domain.AddTrackPointsRequest) error
 	}
 
 	Queries interface {
@@ -47,10 +48,10 @@ type (
 // Dummy for interface
 var _ App = (*Application)(nil)
 
-func New(bookingsRepo domain.BookingsRepository) *Application {
+func New(bookingsRepo domain.BookingsRepository, distanceCalc commands.DistanceCalculator) *Application {
 	return &Application{
 		appCommands{
-			UpdateBookingsHandler: commands.NewUpdateBookingsHandler(domain.NewBookings(bookingsRepo)),
+			UpdateBookingsHandler: commands.NewUpdateBookingsHandler(domain.NewBookings(bookingsRepo), distanceCalc),
 		},
 		appQueries{
 			GetBookingsHandler: queries.NewGetBookingsHandler(domain.NewBookings(bookingsRepo)),

--- a/bookings/internal/pkg/application/application_test.go
+++ b/bookings/internal/pkg/application/application_test.go
@@ -21,7 +21,14 @@ import (
 
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/domain"
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/persistance/postgresql"
+	extdomain "github.com/arngrimur/bilcool_monolith/bookings/pkg/domain"
 )
+
+type noopDistanceCalc struct{}
+
+func (noopDistanceCalc) CalculateRoadDistance(_ context.Context, _ []extdomain.TrackPoint) (int, error) {
+	return 0, nil
+}
 
 type applicationTestSuite struct {
 	suite.Suite
@@ -78,7 +85,7 @@ func TestRunSuiteApplication(t *testing.T) {
 // region tests
 func (suite *applicationTestSuite) TestGetASingleBooking() {
 	bookingRepository := postgresql.NewBookingsRepository(suite.Db)
-	application := New(bookingRepository)
+	application := New(bookingRepository, noopDistanceCalc{})
 	booking, err := application.GetBooking(context.Background(), domain.BookingRequest{BookingReference: suite.bookingRef})
 	suite.Require().NoError(err)
 	suite.Require().Equal(suite.bookingRef, booking.BookingReference, "Booking reference should be the same")
@@ -86,7 +93,7 @@ func (suite *applicationTestSuite) TestGetASingleBooking() {
 
 func (suite *applicationTestSuite) TestUpdateBooking() {
 	bookingRepository := postgresql.NewBookingsRepository(suite.Db)
-	application := New(bookingRepository)
+	application := New(bookingRepository, noopDistanceCalc{})
 	r := domain.UpdateBookingRequest{
 		BookingReference: uuid.New(),
 		StartDate:        suite.now,

--- a/bookings/internal/pkg/application/commands/update_booking.go
+++ b/bookings/internal/pkg/application/commands/update_booking.go
@@ -3,16 +3,25 @@ package commands
 import (
 	"context"
 
+	"github.com/rs/zerolog/log"
+
 	"github.com/arngrimur/bilcool_monolith/bookings/internal/pkg/domain"
+	extdomain "github.com/arngrimur/bilcool_monolith/bookings/pkg/domain"
 )
+
+type DistanceCalculator interface {
+	CalculateRoadDistance(ctx context.Context, points []extdomain.TrackPoint) (int, error)
+}
 
 type UpdateBookingsHandler struct {
 	*domain.Bookings
+	distanceCalc DistanceCalculator
 }
 
-func NewUpdateBookingsHandler(bookings *domain.Bookings) UpdateBookingsHandler {
+func NewUpdateBookingsHandler(bookings *domain.Bookings, distanceCalc DistanceCalculator) UpdateBookingsHandler {
 	return UpdateBookingsHandler{
-		Bookings: bookings,
+		Bookings:     bookings,
+		distanceCalc: distanceCalc,
 	}
 }
 
@@ -25,6 +34,24 @@ func (h UpdateBookingsHandler) DeleteBooking(ctx context.Context, request domain
 }
 
 func (h UpdateBookingsHandler) EndBooking(ctx context.Context, request domain.EndBookingRequest) error {
+	if request.OdometerStart != nil && request.OdometerEnd != nil {
+		request.Distance = extdomain.Distance{
+			StartDistance: *request.OdometerStart,
+			EndDistance:   *request.OdometerEnd,
+		}
+	} else {
+		points, err := h.Bookings.GetTrackPoints(ctx, request.BookingRequest)
+		if err != nil {
+			log.Ctx(ctx).Warn().Err(err).Msg("failed to get track points for distance calculation")
+		} else if len(points) >= 2 {
+			meters, err := h.distanceCalc.CalculateRoadDistance(ctx, points)
+			if err != nil {
+				log.Ctx(ctx).Warn().Err(err).Msg("mapbox distance calculation failed, distance will be 0")
+			} else {
+				request.Distance = extdomain.Distance{StartDistance: 0, EndDistance: meters}
+			}
+		}
+	}
 	return h.Bookings.EndBooking(ctx, request)
 }
 
@@ -34,4 +61,8 @@ func (h UpdateBookingsHandler) PauseBooking(ctx context.Context, request domain.
 
 func (h UpdateBookingsHandler) ResumeBooking(ctx context.Context, request domain.BookingRequest) (domain.PauseBookingResponse, error) {
 	return h.Bookings.ResumeBooking(ctx, request)
+}
+
+func (h UpdateBookingsHandler) AddTrackPoints(ctx context.Context, request domain.AddTrackPointsRequest) error {
+	return h.Bookings.AddTrackPoints(ctx, request)
 }

--- a/bookings/internal/pkg/config/config.go
+++ b/bookings/internal/pkg/config/config.go
@@ -6,9 +6,10 @@ import (
 )
 
 var (
-	databaseUrl string
-	outboxMode  string
-	ginMode     string
+	databaseUrl        string
+	outboxMode         string
+	ginMode            string
+	mapboxAccessToken  string
 )
 
 func DatabaseUrl() string {
@@ -35,9 +36,14 @@ func Init() error {
 	} else {
 		ginMode = "debug"
 	}
+	mapboxAccessToken, _ = os.LookupEnv("MAPBOX_ACCESS_TOKEN")
 	return nil
 }
 
 func GinMode() string {
 	return ginMode
+}
+
+func MapboxAccessToken() string {
+	return mapboxAccessToken
 }

--- a/bookings/internal/pkg/domain/bookings.go
+++ b/bookings/internal/pkg/domain/bookings.go
@@ -23,8 +23,15 @@ type BookingRequest struct {
 
 type EndBookingRequest struct {
 	BookingRequest
-	extdomain.Distance
-	Position *extdomain.Position
+	OdometerStart *int                `json:"odometer_start,omitempty"`
+	OdometerEnd   *int                `json:"odometer_end,omitempty"`
+	Position      *extdomain.Position `json:"position,omitempty"`
+	Distance      extdomain.Distance  // populated by command handler, not from HTTP
+}
+
+type AddTrackPointsRequest struct {
+	BookingRequest
+	Points []extdomain.TrackPoint `json:"points"`
 }
 
 type PauseBookingRequest struct {
@@ -80,4 +87,12 @@ func (b Bookings) PauseBooking(ctx context.Context, request PauseBookingRequest)
 
 func (b Bookings) ResumeBooking(ctx context.Context, request BookingRequest) (PauseBookingResponse, error) {
 	return b.r.ResumeBooking(ctx, request)
+}
+
+func (b Bookings) AddTrackPoints(ctx context.Context, request AddTrackPointsRequest) error {
+	return b.r.AddTrackPoints(ctx, request)
+}
+
+func (b Bookings) GetTrackPoints(ctx context.Context, request BookingRequest) ([]extdomain.TrackPoint, error) {
+	return b.r.GetTrackPoints(ctx, request)
 }

--- a/bookings/internal/pkg/domain/bookings_repository.go
+++ b/bookings/internal/pkg/domain/bookings_repository.go
@@ -18,4 +18,6 @@ type BookingsRepository interface {
 	ResumeBooking(ctx context.Context, request BookingRequest) (PauseBookingResponse, error)
 	AddUser(ctx context.Context, message brokerpostgres.Message) error
 	DeleteUser(ctx context.Context, message brokerpostgres.Message) error
+	AddTrackPoints(ctx context.Context, request AddTrackPointsRequest) error
+	GetTrackPoints(ctx context.Context, request BookingRequest) ([]ext_domain.TrackPoint, error)
 }

--- a/bookings/internal/pkg/domain/bookings_repository_mock.go
+++ b/bookings/internal/pkg/domain/bookings_repository_mock.go
@@ -42,6 +42,20 @@ func (m *MockBookingsRepository) EXPECT() *MockBookingsRepositoryMockRecorder {
 	return m.recorder
 }
 
+// AddTrackPoints mocks base method.
+func (m *MockBookingsRepository) AddTrackPoints(ctx context.Context, request AddTrackPointsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTrackPoints", ctx, request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTrackPoints indicates an expected call of AddTrackPoints.
+func (mr *MockBookingsRepositoryMockRecorder) AddTrackPoints(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTrackPoints", reflect.TypeOf((*MockBookingsRepository)(nil).AddTrackPoints), ctx, request)
+}
+
 // AddUser mocks base method.
 func (m *MockBookingsRepository) AddUser(ctx context.Context, message postgres.Message) error {
 	m.ctrl.T.Helper()
@@ -126,6 +140,21 @@ func (m *MockBookingsRepository) FindAll(ctx context.Context) ([]domain.BookingR
 func (mr *MockBookingsRepositoryMockRecorder) FindAll(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockBookingsRepository)(nil).FindAll), ctx)
+}
+
+// GetTrackPoints mocks base method.
+func (m *MockBookingsRepository) GetTrackPoints(ctx context.Context, request BookingRequest) ([]domain.TrackPoint, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTrackPoints", ctx, request)
+	ret0, _ := ret[0].([]domain.TrackPoint)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrackPoints indicates an expected call of GetTrackPoints.
+func (mr *MockBookingsRepositoryMockRecorder) GetTrackPoints(ctx, request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrackPoints", reflect.TypeOf((*MockBookingsRepository)(nil).GetTrackPoints), ctx, request)
 }
 
 // PauseBooking mocks base method.

--- a/bookings/internal/pkg/infrastructure/mapbox/map_matching.go
+++ b/bookings/internal/pkg/infrastructure/mapbox/map_matching.go
@@ -1,0 +1,122 @@
+package mapbox
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"strings"
+
+	extdomain "github.com/arngrimur/bilcool_monolith/bookings/pkg/domain"
+)
+
+const mapMatchingURL = "https://api.mapbox.com/matching/v5/mapbox/driving"
+const maxWaypoints = 100
+
+type Client struct {
+	accessToken string
+	httpClient  *http.Client
+}
+
+func NewClient(accessToken string) *Client {
+	return &Client{
+		accessToken: accessToken,
+		httpClient:  &http.Client{},
+	}
+}
+
+type matchingResponse struct {
+	Code      string `json:"code"`
+	Matchings []struct {
+		Distance float64 `json:"distance"`
+	} `json:"matchings"`
+}
+
+// CalculateRoadDistance returns total road distance in meters between the provided GPS points
+// using the Mapbox Map Matching API. Falls back to Haversine sum on API failure.
+func (c *Client) CalculateRoadDistance(ctx context.Context, points []extdomain.TrackPoint) (int, error) {
+	if len(points) < 2 {
+		return 0, nil
+	}
+
+	totalMeters := 0.0
+
+	// Split into chunks of maxWaypoints, overlapping by 1 point so coverage is complete
+	for start := 0; start < len(points)-1; start += maxWaypoints - 1 {
+		end := start + maxWaypoints
+		if end > len(points) {
+			end = len(points)
+		}
+		chunk := points[start:end]
+
+		meters, err := c.matchSegment(ctx, chunk)
+		if err != nil {
+			// Fall back to Haversine for this chunk
+			meters = haversineChain(chunk)
+		}
+		totalMeters += meters
+	}
+
+	return int(math.Round(totalMeters)), nil
+}
+
+func (c *Client) matchSegment(ctx context.Context, points []extdomain.TrackPoint) (float64, error) {
+	coords := make([]string, len(points))
+	for i, p := range points {
+		coords[i] = fmt.Sprintf("%f,%f", p.Lon, p.Lat) // Mapbox expects lon,lat
+	}
+	coordStr := strings.Join(coords, ";")
+
+	url := fmt.Sprintf("%s/%s?access_token=%s&overview=false&geometries=polyline",
+		mapMatchingURL, coordStr, c.accessToken)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("mapbox returned status %d", resp.StatusCode)
+	}
+
+	var result matchingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, err
+	}
+
+	if result.Code != "Ok" {
+		return 0, fmt.Errorf("mapbox code: %s", result.Code)
+	}
+
+	total := 0.0
+	for _, m := range result.Matchings {
+		total += m.Distance
+	}
+	return total, nil
+}
+
+// haversineChain sums straight-line distances between consecutive points (fallback).
+func haversineChain(points []extdomain.TrackPoint) float64 {
+	total := 0.0
+	for i := 1; i < len(points); i++ {
+		total += haversineMeters(points[i-1].Lat, points[i-1].Lon, points[i].Lat, points[i].Lon)
+	}
+	return total
+}
+
+func haversineMeters(lat1, lon1, lat2, lon2 float64) float64 {
+	const R = 6371000
+	φ1 := lat1 * math.Pi / 180
+	φ2 := lat2 * math.Pi / 180
+	Δφ := (lat2 - lat1) * math.Pi / 180
+	Δλ := (lon2 - lon1) * math.Pi / 180
+	a := math.Sin(Δφ/2)*math.Sin(Δφ/2) + math.Cos(φ1)*math.Cos(φ2)*math.Sin(Δλ/2)*math.Sin(Δλ/2)
+	return R * 2 * math.Atan2(math.Sqrt(a), math.Sqrt(1-a))
+}

--- a/bookings/internal/pkg/persistance/postgresql/bookings.go
+++ b/bookings/internal/pkg/persistance/postgresql/bookings.go
@@ -174,7 +174,7 @@ func (bdb BookingRepository) EndBooking(ctx context.Context, request domain.EndB
 		return err
 	}
 	q := "INSERT INTO distances (fk_booking_id, start_distance, end_distance) VALUES ($1, $2, $3)"
-	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.StartDistance, request.EndDistance)
+	_, err = local_bdb.ExecContext(ctx, q, booking.id, request.Distance.StartDistance, request.Distance.EndDistance)
 	if err != nil {
 		return err
 	}
@@ -327,6 +327,52 @@ func (bdb BookingRepository) DeleteUser(ctx context.Context, m brokerpostgres.Me
 		return err
 	}
 	return tx.Commit()
+}
+
+func (bdb BookingRepository) AddTrackPoints(ctx context.Context, request domain.AddTrackPointsRequest) error {
+	var bookingID int
+	err := bdb.QueryRowContext(ctx,
+		`SELECT id FROM bookings WHERE booking_reference = $1`,
+		request.BookingReference,
+	).Scan(&bookingID)
+	if err != nil {
+		return err
+	}
+
+	for _, p := range request.Points {
+		_, err = bdb.ExecContext(ctx,
+			`INSERT INTO gps_track_points (fk_booking_id, lat, lon, recorded_at) VALUES ($1, $2, $3, $4)`,
+			bookingID, p.Lat, p.Lon, p.RecordedAt,
+		)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (bdb BookingRepository) GetTrackPoints(ctx context.Context, request domain.BookingRequest) ([]extdomain.TrackPoint, error) {
+	rows, err := bdb.QueryContext(ctx,
+		`SELECT lat, lon, recorded_at
+         FROM gps_track_points
+         WHERE fk_booking_id = (SELECT id FROM bookings WHERE booking_reference = $1)
+         ORDER BY recorded_at ASC`,
+		request.BookingReference,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var points []extdomain.TrackPoint
+	for rows.Next() {
+		var p extdomain.TrackPoint
+		if err := rows.Scan(&p.Lat, &p.Lon, &p.RecordedAt); err != nil {
+			return nil, err
+		}
+		points = append(points, p)
+	}
+	return points, rows.Err()
 }
 
 func (bdb BookingRepository) userRef(m brokerpostgres.Message) (uuid.UUID, error) {

--- a/bookings/internal/pkg/web/handlers_test.go
+++ b/bookings/internal/pkg/web/handlers_test.go
@@ -50,6 +50,9 @@ func (s *stubCommands) PauseBooking(_ context.Context, _ domain.PauseBookingRequ
 func (s *stubCommands) ResumeBooking(_ context.Context, _ domain.BookingRequest) (domain.PauseBookingResponse, error) {
 	return s.resumeResp, s.resumeErr
 }
+func (s *stubCommands) AddTrackPoints(_ context.Context, _ domain.AddTrackPointsRequest) error {
+	return nil
+}
 
 // stubQueries implements application.Queries returning zero values.
 type stubQueries struct{}

--- a/bookings/internal/pkg/web/router.go
+++ b/bookings/internal/pkg/web/router.go
@@ -86,6 +86,7 @@ func commandRoutes(h *HttpRouter) {
 	h.router.POST("/api/v1/bookings/:id/end", h.endBooking)
 	h.router.POST("/api/v1/bookings/:id/pause", h.pauseBooking)
 	h.router.POST("/api/v1/bookings/:id/resume", h.resumeBooking)
+	h.router.POST("/api/v1/bookings/:id/track", h.addTrackPoints)
 }
 
 func (h *HttpRouter) Engine() *gin.Engine { return h.router }
@@ -292,8 +293,9 @@ func (h *HttpRouter) endBooking(c *gin.Context) {
 		return
 	}
 	var body struct {
-		extdomain.Distance
-		Position *extdomain.Position `json:"position,omitempty"`
+		OdometerStart *int                `json:"odometer_start,omitempty"`
+		OdometerEnd   *int                `json:"odometer_end,omitempty"`
+		Position      *extdomain.Position `json:"position,omitempty"`
 	}
 	err = c.ShouldBindBodyWithJSON(&body)
 	if err != nil {
@@ -302,12 +304,38 @@ func (h *HttpRouter) endBooking(c *gin.Context) {
 	}
 	err = h.commands.EndBooking(c.Request.Context(), domain.EndBookingRequest{
 		BookingRequest: domain.BookingRequest{BookingReference: id},
-		Distance:       body.Distance,
+		OdometerStart:  body.OdometerStart,
+		OdometerEnd:    body.OdometerEnd,
 		Position:       body.Position,
 	})
 	if err != nil {
 		e := NewHttpError(err)
 		NewError(c, e.Code, fmt.Errorf("failed to end booking %s", e.Message))
+		return
+	}
+	c.Status(http.StatusAccepted)
+}
+
+func (h *HttpRouter) addTrackPoints(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid format or missing id"})
+		return
+	}
+	var body struct {
+		Points []extdomain.TrackPoint `json:"points"`
+	}
+	if err = c.ShouldBindBodyWithJSON(&body); err != nil || len(body.Points) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid body"})
+		return
+	}
+	err = h.commands.AddTrackPoints(c.Request.Context(), domain.AddTrackPointsRequest{
+		BookingRequest: domain.BookingRequest{BookingReference: id},
+		Points:         body.Points,
+	})
+	if err != nil {
+		e := NewHttpError(err)
+		NewError(c, e.Code, fmt.Errorf("failed to add track points %s", e.Message))
 		return
 	}
 	c.Status(http.StatusAccepted)

--- a/bookings/pkg/domain/completed_booking.go
+++ b/bookings/pkg/domain/completed_booking.go
@@ -13,6 +13,12 @@ type Position struct {
 	Lon float64 `json:"lon"`
 }
 
+type TrackPoint struct {
+	Lat        float64   `json:"lat"`
+	Lon        float64   `json:"lon"`
+	RecordedAt time.Time `json:"recorded_at"`
+}
+
 type CompletedBooking struct {
 	Booking  BookingResponse `json:"booking"`
 	Distance Distance        `json:"distance"`

--- a/ui/bilcool-ui/src/api/bookings.ts
+++ b/ui/bilcool-ui/src/api/bookings.ts
@@ -5,6 +5,7 @@ import type {
   EndBookingRequest,
   PauseBookingRequest,
   PauseBookingResponse,
+  TrackPoint,
 } from '../types/api';
 
 const BASE = '/api/v1';
@@ -29,3 +30,9 @@ export const pauseBooking = (id: string, body: PauseBookingRequest) =>
 
 export const resumeBooking = (id: string) =>
   apiFetch<PauseBookingResponse>(`${BASE}/bookings/${id}/resume`, { method: 'POST' });
+
+export const addTrackPoints = (id: string, points: TrackPoint[]) =>
+  apiFetch<void>(`${BASE}/bookings/${id}/track`, {
+    method: 'POST',
+    body: JSON.stringify({ points }),
+  });

--- a/ui/bilcool-ui/src/components/bookings/ActiveBookingTracker.tsx
+++ b/ui/bilcool-ui/src/components/bookings/ActiveBookingTracker.tsx
@@ -1,12 +1,10 @@
 import { useTranslation } from 'react-i18next'
 import { useGpsTracking } from '../../hooks/useGpsTracking'
-import { useEndBooking, usePauseBooking, useResumeBooking } from '../../hooks/useBookings'
+import { useEndBooking, usePauseBooking, useResumeBooking, useAddTrackPoints } from '../../hooks/useBookings'
 import { Button } from '../ui/button'
-import type { BookingResponse } from '../../types/api'
+import type { BookingResponse, TrackPoint } from '../../types/api'
 import { formatTime } from '../../utils/dateUtils'
 import { useSettingsStore } from '../../stores/settingsStore'
-
-const LOW_SPEED_THRESHOLD_KMH = 7
 
 interface Props {
   booking: BookingResponse
@@ -19,18 +17,14 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
   const endBooking = useEndBooking()
   const pauseBooking = usePauseBooking()
   const resumeBooking = useResumeBooking()
-  const {
-    isTracking,
-    isPaused,
-    distanceMeters,
-    currentPosition,
-    currentSpeedKmh,
-    error,
-    startTracking,
-    stopTracking,
-    pauseTracking,
-    resumeTracking,
-  } = useGpsTracking()
+  const addTrackPoints = useAddTrackPoints()
+
+  const onPoint = async (point: TrackPoint) => {
+    await addTrackPoints.mutateAsync({ id: booking.booking_reference, points: [point] })
+  }
+
+  const { isTracking, isPaused, currentPosition, error, startTracking, stopTracking, pauseTracking, resumeTracking } =
+    useGpsTracking({ onPoint })
 
   const now = new Date()
   const hasOtherActive = allBookings.some(
@@ -41,15 +35,11 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
       !b.distance,
   )
 
-  const canPause = currentSpeedKmh < LOW_SPEED_THRESHOLD_KMH
-
   async function handleStop() {
-    const finalDistance = stopTracking()
+    stopTracking()
     await endBooking.mutateAsync({
       id: booking.booking_reference,
       body: {
-        start_distance: 0,
-        end_distance: Math.round(finalDistance),
         position: currentPosition ?? undefined,
       },
     })
@@ -66,8 +56,8 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
   }
 
   async function handleResume() {
-    const response = await resumeBooking.mutateAsync(booking.booking_reference)
-    resumeTracking(response.position)
+    await resumeBooking.mutateAsync(booking.booking_reference)
+    resumeTracking()
   }
 
   return (
@@ -83,18 +73,13 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
         {formatTime(booking.start_date, language)} – {formatTime(booking.end_date, language)}
       </p>
 
-      {error && (
-        <p className="text-sm text-destructive">{error}</p>
-      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
 
       {isTracking ? (
         <div className="space-y-3">
-          <div className="text-center py-2">
-            <p className="text-3xl font-bold tabular-nums">
-              {(distanceMeters / 1000).toFixed(2)} km
-            </p>
-            <p className="text-xs text-muted-foreground mt-1">{t('tracking_distance_label')}</p>
-          </div>
+          {!isPaused && (
+            <p className="text-sm text-center text-muted-foreground py-2">{t('tracking_active_label')}</p>
+          )}
 
           {isPaused ? (
             <Button
@@ -110,8 +95,7 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
                 className="flex-1 min-h-[52px] text-base"
                 variant="outline"
                 onClick={handlePause}
-                disabled={!canPause || pauseBooking.isPending}
-                title={!canPause ? t('pause_speed_hint') : undefined}
+                disabled={pauseBooking.isPending}
               >
                 {pauseBooking.isPending ? '...' : t('pause_tracking')}
               </Button>
@@ -131,10 +115,7 @@ export default function ActiveBookingTracker({ booking, allBookings }: Props) {
           {hasOtherActive ? (
             <p className="text-sm text-muted-foreground">{t('other_booking_active')}</p>
           ) : (
-            <Button
-              className="w-full min-h-[52px] text-base"
-              onClick={startTracking}
-            >
+            <Button className="w-full min-h-[52px] text-base" onClick={startTracking}>
               {t('start_tracking')}
             </Button>
           )}

--- a/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
+++ b/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
@@ -3,7 +3,7 @@ import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { useTranslation } from 'react-i18next'
-import { useDeleteBooking, useEndBooking, usePauseBooking, useResumeBooking } from '../../hooks/useBookings'
+import { useDeleteBooking, useEndBooking, usePauseBooking, useResumeBooking, useAddTrackPoints } from '../../hooks/useBookings'
 import { useGpsTracking } from '../../hooks/useGpsTracking'
 import { Button } from '../ui/button'
 import { Input } from '../ui/input'
@@ -15,7 +15,7 @@ import {
   DialogTitle,
   DialogFooter,
 } from '../ui/dialog'
-import type { BookingResponse } from '../../types/api'
+import type { BookingResponse, TrackPoint } from '../../types/api'
 import { formatDate, formatTime } from '../../utils/dateUtils'
 import { useSettingsStore } from '../../stores/settingsStore'
 
@@ -54,21 +54,23 @@ export default function BookingStartEndDialog({
   const endBooking = useEndBooking()
   const pauseBooking = usePauseBooking()
   const resumeBooking = useResumeBooking()
+  const addTrackPoints = useAddTrackPoints()
+
+  const onPoint = async (point: TrackPoint) => {
+    await addTrackPoints.mutateAsync({ id: booking.booking_reference, points: [point] })
+  }
+
   const {
     isTracking,
     isPaused,
-    distanceMeters,
     currentPosition,
-    currentSpeedKmh,
     error: gpsError,
     startTracking,
     stopTracking,
     pauseTracking,
     resumeTracking,
-  } = useGpsTracking()
+  } = useGpsTracking({ onPoint })
 
-  const LOW_SPEED_THRESHOLD_KMH = 7
-  const canPause = currentSpeedKmh < LOW_SPEED_THRESHOLD_KMH
   const [confirmCancel, setConfirmCancel] = useState(false)
 
   useEffect(() => {
@@ -99,8 +101,6 @@ export default function BookingStartEndDialog({
     await endBooking.mutateAsync({
       id: booking.booking_reference,
       body: {
-        start_distance: 0,
-        end_distance: Math.round(distanceMeters),
         position: currentPosition ?? undefined,
       },
     })
@@ -118,16 +118,16 @@ export default function BookingStartEndDialog({
   }
 
   async function handleResumeGps() {
-    const response = await resumeBooking.mutateAsync(booking.booking_reference)
-    resumeTracking(response.position)
+    await resumeBooking.mutateAsync(booking.booking_reference)
+    resumeTracking()
   }
 
   async function handleEnd(data: EndFormValues) {
     await endBooking.mutateAsync({
       id: booking.booking_reference,
       body: {
-        start_distance: data.startOdo * 1000,
-        end_distance: data.endOdo * 1000,
+        odometer_start: data.startOdo * 1000,
+        odometer_end: data.endOdo * 1000,
       },
     })
     onOpenChange(false)
@@ -167,12 +167,9 @@ export default function BookingStartEndDialog({
 
             {isTracking ? (
               <div className="space-y-3">
-                <div className="text-center py-2">
-                  <p className="text-3xl font-bold tabular-nums">
-                    {(distanceMeters / 1000).toFixed(2)} km
-                  </p>
-                  <p className="text-xs text-muted-foreground mt-1">{t('tracking_distance_label')}</p>
-                </div>
+                {!isPaused && (
+                  <p className="text-sm text-center text-muted-foreground py-2">{t('tracking_active_label')}</p>
+                )}
                 {isPaused ? (
                   <Button
                     className="w-full min-h-[52px] text-base"
@@ -187,8 +184,7 @@ export default function BookingStartEndDialog({
                       className="flex-1 min-h-[52px] text-base"
                       variant="outline"
                       onClick={handlePauseGps}
-                      disabled={!canPause || pauseBooking.isPending}
-                      title={!canPause ? t('pause_speed_hint') : undefined}
+                      disabled={pauseBooking.isPending}
                     >
                       {pauseBooking.isPending ? '...' : t('pause_tracking')}
                     </Button>

--- a/ui/bilcool-ui/src/hooks/useBookings.ts
+++ b/ui/bilcool-ui/src/hooks/useBookings.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listBookings, upsertBooking, deleteBooking, endBooking, pauseBooking, resumeBooking } from '../api/bookings'
-import type { UpdateBookingRequest, EndBookingRequest, PauseBookingRequest } from '../types/api'
+import { listBookings, upsertBooking, deleteBooking, endBooking, pauseBooking, resumeBooking, addTrackPoints } from '../api/bookings'
+import type { UpdateBookingRequest, EndBookingRequest, PauseBookingRequest, TrackPoint } from '../types/api'
 
 export function useBookings() {
   return useQuery({
@@ -51,5 +51,12 @@ export function usePauseBooking() {
 export function useResumeBooking() {
   return useMutation({
     mutationFn: (id: string) => resumeBooking(id),
+  })
+}
+
+export function useAddTrackPoints() {
+  return useMutation({
+    mutationFn: ({ id, points }: { id: string; points: TrackPoint[] }) =>
+      addTrackPoints(id, points),
   })
 }

--- a/ui/bilcool-ui/src/hooks/useGpsTracking.test.ts
+++ b/ui/bilcool-ui/src/hooks/useGpsTracking.test.ts
@@ -1,391 +1,113 @@
 import { act, renderHook } from '@testing-library/react'
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useGpsTracking } from './useGpsTracking'
 
-const HIGH_SPEED_KMH = 15
-const LOW_SPEED_KMH = 3
-const FIVE_MIN_MS = 5 * 60 * 1000
-
-// Each step moves ~111 metres north, giving a predictable haversine distance
-function makePosition(step: number, speedKmh: number, timestamp: number): GeolocationPosition {
-  return {
-    coords: {
-      latitude: 59.0 + step * 0.001,
-      longitude: 18.0,
-      speed: speedKmh / 3.6, // m/s, as the Geolocation API provides
-      accuracy: 10,
-      altitude: null,
-      altitudeAccuracy: null,
-      heading: null,
+function mockGeolocation(lat: number, lon: number) {
+  Object.defineProperty(navigator, 'geolocation', {
+    value: {
+      getCurrentPosition: vi.fn((success: PositionCallback) => {
+        success({
+          coords: { latitude: lat, longitude: lon, speed: null, accuracy: 10, altitude: null, altitudeAccuracy: null, heading: null },
+          timestamp: Date.now(),
+        } as GeolocationPosition)
+      }),
     },
-    timestamp,
-  } as GeolocationPosition
+    writable: true,
+    configurable: true,
+  })
 }
 
 describe('useGpsTracking', () => {
-  let sendPosition: (pos: GeolocationPosition) => void
-
   beforeEach(() => {
-    Object.defineProperty(navigator, 'geolocation', {
-      value: {
-        watchPosition: vi.fn((successCb: (position: GeolocationPosition) => void) => {
-          sendPosition = (pos) => act(() => successCb(pos))
-          return 1
-        }),
-        clearWatch: vi.fn(),
-      },
-      writable: true,
-      configurable: true,
-    })
+    vi.useFakeTimers()
+    mockGeolocation(59.0, 18.0)
   })
 
-  it('accumulates distance while speed stays above 7 km/h', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(0)
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
-  it('counts distance accumulated during a brief low-speed window shorter than 5 minutes', () => {
+  it('isTracking is false before startTracking', () => {
     const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distanceBeforeSlow = result.current.distanceMeters
-
-    // 2-minute slow window — below the 5-minute threshold
-    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
-    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + 2 * 60_000))
-
-    // Recover to high speed
-    sendPosition(makePosition(4, HIGH_SPEED_KMH, 2_000 + 2 * 60_000 + 1_000))
-
-    // The distance covered during the brief slow period must still be included
-    expect(result.current.distanceMeters).toBeGreaterThan(distanceBeforeSlow)
+    expect(result.current.isTracking).toBe(false)
   })
 
-  it('retroactively removes distance once low speed is sustained for more than 5 minutes', () => {
+  it('isTracking becomes true after startTracking', () => {
     const { result } = renderHook(() => useGpsTracking())
     act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
-    const distanceBeforeSlow = result.current.distanceMeters
-
-    // Low-speed positions — distance is tentatively added
-    sendPosition(makePosition(3, LOW_SPEED_KMH, 3_000))
-    sendPosition(makePosition(4, LOW_SPEED_KMH, 3_000 + 2 * 60_000))
-    const distanceDuringSlow = result.current.distanceMeters
-    expect(distanceDuringSlow).toBeGreaterThan(distanceBeforeSlow) // tentatively added
-
-    // Cross the 5-minute mark — retroactive removal must trigger
-    sendPosition(makePosition(5, LOW_SPEED_KMH, 3_000 + FIVE_MIN_MS + 1_000))
-
-    expect(result.current.distanceMeters).toBeCloseTo(distanceBeforeSlow, 2)
-    expect(result.current.distanceMeters).toBeLessThan(distanceDuringSlow)
+    expect(result.current.isTracking).toBe(true)
   })
 
-  it('does not accumulate further distance while paused after the 5-minute threshold', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-
-    // Trigger the 5-minute pause
-    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
-    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 1_000))
-    const distanceAtPause = result.current.distanceMeters
-
-    // Further low-speed positions must not add to the total
-    sendPosition(makePosition(4, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 2_000))
-    sendPosition(makePosition(5, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 3_000))
-
-    expect(result.current.distanceMeters).toBe(distanceAtPause)
+  it('calls onPoint immediately on startTracking', async () => {
+    const onPoint = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGpsTracking({ onPoint }))
+    await act(async () => { result.current.startTracking() })
+    expect(onPoint).toHaveBeenCalledTimes(1)
+    expect(onPoint).toHaveBeenCalledWith(expect.objectContaining({ lat: 59.0, lon: 18.0 }))
   })
 
-  it('resumes accumulating distance once speed recovers after a sustained low-speed pause', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distanceBeforeSlow = result.current.distanceMeters
-
-    // Sustained low speed — triggers retroactive removal and pause
-    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
-    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + FIVE_MIN_MS + 1_000))
-    const distanceAfterPause = result.current.distanceMeters
-    expect(distanceAfterPause).toBeCloseTo(distanceBeforeSlow, 2)
-
-    // Recover to high speed — new movement must count again
-    sendPosition(makePosition(4, HIGH_SPEED_KMH, 2_000 + FIVE_MIN_MS + 2_000))
-    sendPosition(makePosition(5, HIGH_SPEED_KMH, 2_000 + FIVE_MIN_MS + 3_000))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(distanceAfterPause)
+  it('calls onPoint again after 2 minutes', async () => {
+    const onPoint = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGpsTracking({ onPoint }))
+    await act(async () => { result.current.startTracking() })
+    await act(async () => { vi.advanceTimersByTime(2 * 60 * 1000) })
+    expect(onPoint).toHaveBeenCalledTimes(2)
   })
 
-  it('resumes accumulation after a screen-lock gap at low speed even when paused', () => {
+  it('stopTracking sets isTracking to false', async () => {
     const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    let t = 0
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, t))
-    t += 1_000
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, t))
-    t += 1_000
-
-    // Sit still for >5 min → retroactive removal + isPaused = true
-    sendPosition(makePosition(1, LOW_SPEED_KMH, t))
-    t += FIVE_MIN_MS + 1_000
-    sendPosition(makePosition(1, LOW_SPEED_KMH, t))
-    const distWhenPaused = result.current.distanceMeters
-
-    // Screen locks for 10 minutes while driving ~1.5 km north (15 steps)
-    t += 10 * 60_000
-    sendPosition(makePosition(16, LOW_SPEED_KMH, t))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(distWhenPaused + 1_000)
-  })
-
-  it('resumes accumulation after a screen-lock gap at high speed', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    let t = 0
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, t))
-    t += 1_000
-
-    // Trigger pause
-    sendPosition(makePosition(0, LOW_SPEED_KMH, t))
-    t += FIVE_MIN_MS + 1_000
-    sendPosition(makePosition(0, LOW_SPEED_KMH, t))
-    const distWhenPaused = result.current.distanceMeters
-
-    // Screen locked for 8 min, unlocked while still driving at speed
-    t += 8 * 60_000
-    sendPosition(makePosition(12, HIGH_SPEED_KMH, t))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(distWhenPaused + 1_000)
-  })
-
-  it('records first and second drive segments but not a 15-minute walk between them', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    let t = 0
-
-    // First drive
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, t))
-    t += 1_000
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, t))
-    t += 1_000
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, t))
-    const distanceAfterFirstDrive = result.current.distanceMeters
-    expect(distanceAfterFirstDrive).toBeGreaterThan(0)
-
-    // 15-minute walk — three ~5-minute steps, each gap < 6 min to avoid screen-lock detection
-    t += 1_000
-    sendPosition(makePosition(3, LOW_SPEED_KMH, t))       // start walking
-    t += FIVE_MIN_MS + 1_000                               // 5 min → retroactive removal fires
-    sendPosition(makePosition(4, LOW_SPEED_KMH, t))
-    t += FIVE_MIN_MS - 1_000                               // another 5 min
-    sendPosition(makePosition(5, LOW_SPEED_KMH, t))
-    t += FIVE_MIN_MS - 1_000                               // another 5 min (15 min total)
-    sendPosition(makePosition(6, LOW_SPEED_KMH, t))
-
-    // Walk distance must have been stripped
-    expect(result.current.distanceMeters).toBeCloseTo(distanceAfterFirstDrive, 2)
-
-    // Second drive
-    t += 1_000
-    sendPosition(makePosition(7, HIGH_SPEED_KMH, t))
-    t += 1_000
-    sendPosition(makePosition(8, HIGH_SPEED_KMH, t))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(distanceAfterFirstDrive)
-  })
-
-  it('discards trailing low-speed distance when stopping before the 5-minute threshold', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distanceAfterDriving = result.current.distanceMeters
-
-    // Walk for 2 minutes — tentative accumulation, threshold not yet crossed
-    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
-    sendPosition(makePosition(3, LOW_SPEED_KMH, 2_000 + 2 * 60_000))
-
-    // Stop while still in the tentative low-speed window
+    await act(async () => { result.current.startTracking() })
     act(() => result.current.stopTracking())
-
-    expect(result.current.distanceMeters).toBeCloseTo(distanceAfterDriving, 2)
+    expect(result.current.isTracking).toBe(false)
   })
 
-  it('records zero when the entire session is a walk (< 5 min)', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, LOW_SPEED_KMH, 0))
-    sendPosition(makePosition(1, LOW_SPEED_KMH, 1_000))
-    sendPosition(makePosition(2, LOW_SPEED_KMH, 2_000))
-
+  it('no more onPoint calls after stopTracking', async () => {
+    const onPoint = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGpsTracking({ onPoint }))
+    await act(async () => { result.current.startTracking() })
     act(() => result.current.stopTracking())
-
-    expect(result.current.distanceMeters).toBe(0)
+    await act(async () => { vi.advanceTimersByTime(4 * 60 * 1000) })
+    expect(onPoint).toHaveBeenCalledTimes(1) // only the initial sample
   })
 
-  // Manual pause / resume
-
-  it('isPaused is false before any manual pause', () => {
+  it('isPaused becomes true after pauseTracking', async () => {
     const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    expect(result.current.isPaused).toBe(false)
-  })
-
-  it('isPaused becomes true after calling pauseTracking', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
+    await act(async () => { result.current.startTracking() })
     act(() => { result.current.pauseTracking() })
     expect(result.current.isPaused).toBe(true)
   })
 
-  it('pauseTracking returns the last known GPS position', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 0))
-
-    let savedPos: ReturnType<typeof result.current.pauseTracking> = null
-    act(() => { savedPos = result.current.pauseTracking() })
-
-    expect(savedPos).not.toBeNull()
-    expect(savedPos!.lat).toBeCloseTo(59.002, 5)
-    expect(savedPos!.lon).toBeCloseTo(18.0, 5)
+  it('no more onPoint calls while paused', async () => {
+    const onPoint = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGpsTracking({ onPoint }))
+    await act(async () => { result.current.startTracking() })
+    act(() => { result.current.pauseTracking() })
+    await act(async () => { vi.advanceTimersByTime(4 * 60 * 1000) })
+    expect(onPoint).toHaveBeenCalledTimes(1) // only initial
   })
 
-  it('distance does not change while manually paused', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distBeforePause = result.current.distanceMeters
-
+  it('isPaused becomes false and interval resumes after resumeTracking', async () => {
+    const onPoint = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useGpsTracking({ onPoint }))
+    await act(async () => { result.current.startTracking() })
     act(() => { result.current.pauseTracking() })
-
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
-    sendPosition(makePosition(3, HIGH_SPEED_KMH, 3_000))
-
-    expect(result.current.distanceMeters).toBeCloseTo(distBeforePause, 2)
-  })
-
-  it('isPaused becomes false after resumeTracking', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    act(() => { result.current.pauseTracking() })
-    act(() => { result.current.resumeTracking({ lat: 59.0, lon: 18.0 }) })
+    await act(async () => { result.current.resumeTracking() })
     expect(result.current.isPaused).toBe(false)
+    await act(async () => { vi.advanceTimersByTime(2 * 60 * 1000) })
+    expect(onPoint).toHaveBeenCalledTimes(3) // initial + resume immediate + 2min tick
   })
 
-  it('distance accumulates again after resumeTracking', () => {
+  it('currentPosition is updated on each sample', async () => {
     const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distBeforePause = result.current.distanceMeters
-
-    act(() => { result.current.pauseTracking() })
-    act(() => { result.current.resumeTracking({ lat: 59.001, lon: 18.0 }) })
-
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
-
-    expect(result.current.distanceMeters).toBeGreaterThan(distBeforePause)
+    await act(async () => { result.current.startTracking() })
+    expect(result.current.currentPosition).toEqual({ lat: 59.0, lon: 18.0 })
   })
 
-  it('resumeTracking uses the saved position as the reference, not the latest GPS position', () => {
+  it('pauseTracking returns the current position', async () => {
     const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    sendPosition(makePosition(1, HIGH_SPEED_KMH, 1_000))
-    const distAfterDriving = result.current.distanceMeters
-
-    // Pause — savedPos is at step 1 (lat 59.001)
-    let savedPos: ReturnType<typeof result.current.pauseTracking> = null
-    act(() => { savedPos = result.current.pauseTracking() })
-
-    // GPS fires at step 2 while paused — must not accumulate distance
-    sendPosition(makePosition(2, HIGH_SPEED_KMH, 2_000))
-    expect(result.current.distanceMeters).toBeCloseTo(distAfterDriving, 2)
-
-    // Resume from the saved position (step 1, lat 59.001)
-    act(() => { result.current.resumeTracking(savedPos!) })
-
-    // Step 3 (lat 59.003): distance from saved pos (59.001→59.003) ≈ 222 m
-    // If lastPos was step 2 (59.002) instead, it would only be ≈ 111 m
-    sendPosition(makePosition(3, HIGH_SPEED_KMH, 3_000))
-    const addedAfterResume = result.current.distanceMeters - distAfterDriving
-    expect(addedAfterResume).toBeGreaterThan(150) // must be ~222 m, not ~111 m
-  })
-
-  it('stopTracking resets isPaused to false', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    act(() => { result.current.pauseTracking() })
-    act(() => { result.current.stopTracking() })
-    expect(result.current.isPaused).toBe(false)
-    expect(result.current.isTracking).toBe(false)
-  })
-
-  it('currentSpeedKmh is updated from GPS speed', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    expect(result.current.currentSpeedKmh).toBeCloseTo(HIGH_SPEED_KMH, 0)
-  })
-
-  it('currentSpeedKmh reflects low speed while paused', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, 0))
-    act(() => { result.current.pauseTracking() })
-    sendPosition(makePosition(1, LOW_SPEED_KMH, 1_000))
-    expect(result.current.currentSpeedKmh).toBeCloseTo(LOW_SPEED_KMH, 0)
-  })
-
-  it('does not reset pause state for a short gap (< 6 min)', () => {
-    const { result } = renderHook(() => useGpsTracking())
-    act(() => result.current.startTracking())
-
-    let t = 0
-
-    sendPosition(makePosition(0, HIGH_SPEED_KMH, t))
-    t += 1_000
-
-    // Trigger pause
-    sendPosition(makePosition(0, LOW_SPEED_KMH, t))
-    t += FIVE_MIN_MS + 1_000
-    sendPosition(makePosition(0, LOW_SPEED_KMH, t))
-    const distWhenPaused = result.current.distanceMeters
-
-    // Short gap (20 s) — well under the 6-min threshold, must not reset paused state
-    t += 20_000
-    sendPosition(makePosition(1, LOW_SPEED_KMH, t))
-
-    expect(result.current.distanceMeters).toBeCloseTo(distWhenPaused, 0)
+    await act(async () => { result.current.startTracking() })
+    let pos: ReturnType<typeof result.current.pauseTracking> = null
+    act(() => { pos = result.current.pauseTracking() })
+    expect(pos).toEqual({ lat: 59.0, lon: 18.0 })
   })
 })

--- a/ui/bilcool-ui/src/hooks/useGpsTracking.ts
+++ b/ui/bilcool-ui/src/hooks/useGpsTracking.ts
@@ -1,73 +1,59 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { useSettingsStore } from '../stores/settingsStore'
+import type { TrackPoint } from '../types/api'
+
+const SAMPLE_INTERVAL_MS = 2 * 60 * 1000 // 2 minutes
 
 interface TrackingState {
   isTracking: boolean
   isPaused: boolean
-  distanceMeters: number
   currentPosition: { lat: number; lon: number } | null
-  currentSpeedKmh: number
   error: string | null
 }
 
-const LOW_SPEED_THRESHOLD_KMH = 7
-const LOW_SPEED_PAUSE_MS = 5 * 60 * 1000 // 5 minutes
-// A gap this large between callbacks means the screen was locked (iOS suspends watchPosition)
-const SCREEN_LOCK_GAP_MS = 6 * 60 * 1000
-
-function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
-  const R = 6371000
-  const φ1 = (lat1 * Math.PI) / 180
-  const φ2 = (lat2 * Math.PI) / 180
-  const Δφ = ((lat2 - lat1) * Math.PI) / 180
-  const Δλ = ((lon2 - lon1) * Math.PI) / 180
-  const a = Math.sin(Δφ / 2) ** 2 + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) ** 2
-  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+interface UseGpsTrackingOptions {
+  onPoint?: (point: TrackPoint) => Promise<void>
 }
 
-export function useGpsTracking() {
-  const keepScreenOn = useSettingsStore((s) => s.keepScreenOn)
-  const keepScreenOnRef = useRef(keepScreenOn)
-  keepScreenOnRef.current = keepScreenOn
-
+export function useGpsTracking({ onPoint }: UseGpsTrackingOptions = {}) {
   const [state, setState] = useState<TrackingState>({
     isTracking: false,
     isPaused: false,
-    distanceMeters: 0,
     currentPosition: null,
-    currentSpeedKmh: 0,
     error: null,
   })
 
-  const watchIdRef = useRef<number | null>(null)
-  const wakeLockRef = useRef<WakeLockSentinel | null>(null)
-  // last accepted position (lat, lon, timestamp)
-  const lastPosRef = useRef<{ lat: number; lon: number; ts: number } | null>(null)
-  // when speed first dropped below threshold; null means speed is ok
-  const lowSpeedSinceRef = useRef<number | null>(null)
-  // whether accumulation is auto-paused due to sustained low speed
-  const isAutoPausedRef = useRef(false)
-  // whether the user has manually paused tracking
-  const isManuallyPausedRef = useRef(false)
-  const distanceRef = useRef(0)
-  // distance accumulated since speed dropped below threshold (may be retroactively removed)
-  const lowSpeedAccumRef = useRef(0)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const onPointRef = useRef(onPoint)
+  onPointRef.current = onPoint
 
-  const acquireWakeLock = useCallback(async () => {
-    if (!keepScreenOnRef.current || !('wakeLock' in navigator)) return
-    try {
-      wakeLockRef.current = await navigator.wakeLock.request('screen')
-      wakeLockRef.current.addEventListener('release', () => {
-        wakeLockRef.current = null
-      })
-    } catch {
-    }
+  const samplePosition = useCallback(() => {
+    if (!navigator.geolocation) return
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const point: TrackPoint = {
+          lat: pos.coords.latitude,
+          lon: pos.coords.longitude,
+          recorded_at: new Date(pos.timestamp).toISOString(),
+        }
+        setState((s) => ({ ...s, currentPosition: { lat: point.lat, lon: point.lon }, error: null }))
+        onPointRef.current?.(point).catch(() => {
+          // upload failure is non-fatal — point may be retried next interval
+        })
+      },
+      (err) => setState((s) => ({ ...s, error: err.message })),
+      { enableHighAccuracy: true, maximumAge: 30_000 },
+    )
   }, [])
 
-  const releaseWakeLock = useCallback(async () => {
-    if (wakeLockRef.current) {
-      await wakeLockRef.current.release()
-      wakeLockRef.current = null
+  const startInterval = useCallback(() => {
+    samplePosition() // immediate first sample
+    intervalRef.current = setInterval(samplePosition, SAMPLE_INTERVAL_MS)
+  }, [samplePosition])
+
+  const stopInterval = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
     }
   }, [])
 
@@ -76,170 +62,31 @@ export function useGpsTracking() {
       setState((s) => ({ ...s, error: 'GPS not supported on this device' }))
       return
     }
-    acquireWakeLock()
-    distanceRef.current = 0
-    lastPosRef.current = null
-    lowSpeedSinceRef.current = null
-    isAutoPausedRef.current = false
-    isManuallyPausedRef.current = false
-    lowSpeedAccumRef.current = 0
-
-    const watchId = navigator.geolocation.watchPosition(
-      (pos) => {
-        const { latitude: lat, longitude: lon, speed } = pos.coords
-        const now = pos.timestamp
-
-        // When the screen is locked iOS stops firing callbacks. On unlock the gap between
-        // this update and the last one will be large. Credit the straight-line displacement
-        // unconditionally (the user definitely moved) and reset pause state. Return early
-        // so the normal speed logic does not double-count this segment or mark it tentative.
-        if (lastPosRef.current && now - lastPosRef.current.ts > SCREEN_LOCK_GAP_MS) {
-          if (!isManuallyPausedRef.current) {
-            const gapDist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
-            distanceRef.current += gapDist
-          }
-          isAutoPausedRef.current = false
-          lowSpeedSinceRef.current = null
-          lowSpeedAccumRef.current = 0
-          lastPosRef.current = { lat, lon, ts: now }
-          setState((s) => ({
-            ...s,
-            distanceMeters: distanceRef.current,
-            currentPosition: { lat, lon },
-            error: null,
-          }))
-          return
-        }
-
-        // Derive speed in km/h; fall back to calculating from consecutive points
-        let speedKmh: number
-        if (speed !== null) {
-          speedKmh = speed * 3.6
-        } else if (lastPosRef.current) {
-          const dt = (now - lastPosRef.current.ts) / 1000 // seconds
-          const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
-          speedKmh = dt > 0 ? (dist / dt) * 3.6 : 0
-        } else {
-          speedKmh = 0
-        }
-
-        // Manual pause: only track position, never accumulate distance
-        if (isManuallyPausedRef.current) {
-          lastPosRef.current = { lat, lon, ts: now }
-          setState((s) => ({
-            ...s,
-            currentPosition: { lat, lon },
-            currentSpeedKmh: speedKmh,
-            error: null,
-          }))
-          return
-        }
-
-        if (speedKmh >= LOW_SPEED_THRESHOLD_KMH) {
-          // Speed ok: reset low-speed timer and resume auto-pause state
-          lowSpeedSinceRef.current = null
-          lowSpeedAccumRef.current = 0
-          isAutoPausedRef.current = false
-
-          if (lastPosRef.current) {
-            const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
-            distanceRef.current += dist
-          }
-        } else {
-          // Speed below threshold
-          if (lowSpeedSinceRef.current === null) {
-            lowSpeedSinceRef.current = now
-          }
-          const lowSpeedDuration = now - lowSpeedSinceRef.current
-          if (lowSpeedDuration >= LOW_SPEED_PAUSE_MS) {
-            if (!isAutoPausedRef.current) {
-              // Threshold just crossed: retroactively remove distance accumulated during low-speed window
-              distanceRef.current = Math.max(0, distanceRef.current - lowSpeedAccumRef.current)
-              lowSpeedAccumRef.current = 0
-              isAutoPausedRef.current = true
-            }
-          } else if (!isAutoPausedRef.current && lastPosRef.current) {
-            // Low speed but under the 5-minute threshold: accumulate tentatively
-            const dist = haversineMeters(lastPosRef.current.lat, lastPosRef.current.lon, lat, lon)
-            distanceRef.current += dist
-            lowSpeedAccumRef.current += dist
-          }
-        }
-
-        lastPosRef.current = { lat, lon, ts: now }
-
-        setState((s) => ({
-          ...s,
-          distanceMeters: distanceRef.current,
-          currentPosition: { lat, lon },
-          currentSpeedKmh: speedKmh,
-          error: null,
-        }))
-      },
-      (err) => setState((s) => ({ ...s, error: err.message })),
-      { enableHighAccuracy: true, maximumAge: 0 },
-    )
-
-    watchIdRef.current = watchId
-    setState((s) => ({ ...s, isTracking: true, isPaused: false, distanceMeters: 0, currentSpeedKmh: 0, error: null }))
+    setState((s) => ({ ...s, isTracking: true, isPaused: false, error: null }))
+    startInterval()
   }
 
-  function stopTracking(): number {
-    releaseWakeLock()
-    if (watchIdRef.current !== null) {
-      navigator.geolocation.clearWatch(watchIdRef.current)
-      watchIdRef.current = null
-    }
-    // Discard any tentative low-speed distance that never crossed the 5-minute threshold.
-    // This prevents a short walk (< 5 min) from being counted when the user stops tracking.
-    const finalDistance = Math.max(0, distanceRef.current - lowSpeedAccumRef.current)
-    distanceRef.current = finalDistance
-    lowSpeedAccumRef.current = 0
-    isManuallyPausedRef.current = false
-    setState((s) => ({ ...s, isTracking: false, isPaused: false, distanceMeters: finalDistance }))
-    return finalDistance
+  function stopTracking() {
+    stopInterval()
+    setState((s) => ({ ...s, isTracking: false, isPaused: false }))
   }
 
-  // Manually pause tracking. Returns the current GPS position (to be saved to backend).
   function pauseTracking(): { lat: number; lon: number } | null {
-    isManuallyPausedRef.current = true
-    // Discard tentative low-speed distance
-    distanceRef.current = Math.max(0, distanceRef.current - lowSpeedAccumRef.current)
-    lowSpeedAccumRef.current = 0
-    isAutoPausedRef.current = false
-    lowSpeedSinceRef.current = null
-
-    const pos = lastPosRef.current ? { lat: lastPosRef.current.lat, lon: lastPosRef.current.lon } : null
-    setState((s) => ({ ...s, isPaused: true, distanceMeters: distanceRef.current }))
-    return pos
+    stopInterval()
+    setState((s) => ({ ...s, isPaused: true }))
+    return state.currentPosition
   }
 
-  // Resume tracking from a saved position. The next GPS reading will measure distance from savedPosition.
-  function resumeTracking(savedPosition: { lat: number; lon: number }) {
-    isManuallyPausedRef.current = false
-    // Use the saved pause position as the reference point so distance is measured correctly
-    lastPosRef.current = { lat: savedPosition.lat, lon: savedPosition.lon, ts: Date.now() }
-    lowSpeedSinceRef.current = null
-    isAutoPausedRef.current = false
-    lowSpeedAccumRef.current = 0
+  function resumeTracking(_savedPosition?: { lat: number; lon: number }) {
     setState((s) => ({ ...s, isPaused: false }))
+    startInterval()
   }
 
   useEffect(() => {
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'visible' && watchIdRef.current !== null) {
-        acquireWakeLock()
-      }
-    }
-    document.addEventListener('visibilitychange', onVisibilityChange)
     return () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange)
-      if (watchIdRef.current !== null) {
-        navigator.geolocation.clearWatch(watchIdRef.current)
-      }
-      releaseWakeLock()
+      stopInterval()
     }
-  }, [acquireWakeLock, releaseWakeLock])
+  }, [stopInterval])
 
   return { ...state, startTracking, stopTracking, pauseTracking, resumeTracking }
 }

--- a/ui/bilcool-ui/src/i18n/locales/en/bookings.json
+++ b/ui/bilcool-ui/src/i18n/locales/en/bookings.json
@@ -42,8 +42,7 @@
   "stop_tracking": "Stop",
   "pause_tracking": "Pause",
   "resume_tracking": "Resume",
-  "tracking_distance_label": "Distance tracked",
+  "tracking_active_label": "Tracking active — distance calculated on stop",
   "status_paused": "Paused",
-  "pause_speed_hint": "Speed must be below 7 km/h to pause",
   "other_booking_active": "Another booking is currently active"
 }

--- a/ui/bilcool-ui/src/i18n/locales/sv/bookings.json
+++ b/ui/bilcool-ui/src/i18n/locales/sv/bookings.json
@@ -42,8 +42,7 @@
   "stop_tracking": "Stoppa",
   "pause_tracking": "Pausa",
   "resume_tracking": "Återuppta",
-  "tracking_distance_label": "Körd sträcka",
+  "tracking_active_label": "Spårning aktiv — sträcka beräknas vid stopp",
   "status_paused": "Pausad",
-  "pause_speed_hint": "Farten måste vara under 7 km/h för att pausa",
   "other_booking_active": "En annan bokning är just nu aktiv"
 }

--- a/ui/bilcool-ui/src/types/api.ts
+++ b/ui/bilcool-ui/src/types/api.ts
@@ -77,9 +77,15 @@ export interface UpdateBookingRequest {
   end_date: string;
 }
 
+export interface TrackPoint {
+  lat: number;
+  lon: number;
+  recorded_at: string; // ISO 8601
+}
+
 export interface EndBookingRequest {
-  start_distance: number;
-  end_distance: number;
+  odometer_start?: number;
+  odometer_end?: number;
   position?: { lat: number; lon: number };
 }
 


### PR DESCRIPTION
GPS points are now sampled every 2 minutes on the device (one sample per
interval) and POSTed to a new /api/v1/bookings/{id}/track endpoint. At
booking end the server calls the Mapbox Map Matching API to compute the
actual road distance from stored track points.

Manual odometer readings take priority: if odometer_start and odometer_end
are both present in the end-booking request, Mapbox is skipped entirely.
Haversine is used as a fallback if Mapbox fails.

Changes:
- New gps_track_points table (migration 20260518000000)
- TrackPoint domain type in bookings/pkg/domain
- AddTrackPoints / GetTrackPoints on repository + domain + persistence
- infrastructure/mapbox: Map Matching API client with chunking (max 100
  waypoints per request) and Haversine fallback
- EndBooking command handler resolves distance before repo call
- MAPBOX_ACCESS_TOKEN config var
- UI: useGpsTracking rewritten to setInterval/getCurrentPosition, no
  Haversine, no live distance display
- ActiveBookingTracker / BookingStartEndDialog: removed distance readout
  and speed-based pause restriction; show "tracking active" status instead

https://claude.ai/code/session_01496XDq3euijt9QDVWMGQ59