### PR TITLE
Add CloudWatch Logs read access and fetch-logs workflow

### DIFF
--- a/.github/workflows/fetch-logs.yml
+++ b/.github/workflows/fetch-logs.yml
@@ -1,0 +1,60 @@
+name: Fetch CloudWatch Logs
+
+on:
+  workflow_dispatch:
+    inputs:
+      function:
+        description: Lambda function suffix (e.g. authentication-http, bookings-http)
+        required: true
+        default: authentication-http
+      hours:
+        description: Hours of logs to fetch (max 24)
+        required: true
+        default: "2"
+      filter:
+        description: Optional keyword filter (e.g. "error", "fatal", "login")
+        required: false
+        default: ""
+
+jobs:
+  fetch-logs:
+    name: Fetch CloudWatch Logs
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      REGION: eu-north-1
+      PREFIX: bilcool-production
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: eu-north-1
+
+      - name: Fetch logs
+        run: |
+          FUNCTION="${PREFIX}-${{ github.event.inputs.function }}"
+          LOG_GROUP="/aws/lambda/${FUNCTION}"
+          HOURS="${{ github.event.inputs.hours }}"
+          FILTER="${{ github.event.inputs.filter }}"
+          START_MS=$(( $(date +%s) * 1000 - HOURS * 3600 * 1000 ))
+
+          echo "## CloudWatch Logs: \`${LOG_GROUP}\`" >> $GITHUB_STEP_SUMMARY
+          echo "Last **${HOURS}h** | filter: \`${FILTER:-<none>}\`" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+
+          aws logs filter-log-events \
+            --log-group-name "$LOG_GROUP" \
+            --start-time "$START_MS" \
+            ${FILTER:+--filter-pattern "\"$FILTER\""} \
+            --region "$REGION" \
+            --query 'events[*].[timestamp,message]' \
+            --output text \
+          | while IFS=$'\t' read -r ts msg; do
+              echo "[$(date -d @$(( ts / 1000 )) '+%Y-%m-%d %H:%M:%S' 2>/dev/null || date -r $(( ts / 1000 )) '+%Y-%m-%d %H:%M:%S')] $msg"
+            done >> $GITHUB_STEP_SUMMARY
+
+          echo '```' >> $GITHUB_STEP_SUMMARY

--- a/authentication/internal/pkg/persistance/postgresql/setup.go
+++ b/authentication/internal/pkg/persistance/postgresql/setup.go
@@ -1,7 +1,9 @@
 package postgresql
 
 import (
+	"context"
 	"database/sql"
+	"net/url"
 	"os"
 	"time"
 
@@ -11,16 +13,23 @@ import (
 )
 
 func SetupPostgresDatabase() *sql.DB {
-	psqlDb, err := sql.Open("postgres", config.DatabaseUrl())
+	dbURL := config.DatabaseUrl()
+	if u, err := url.Parse(dbURL); err == nil {
+		log.Info().Str("host", u.Host).Str("db", u.Path).Msg("connecting to database")
+	}
+
+	psqlDb, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error opening database connection")
 	}
-	maxTries := 10
+
+	const maxTries = 10
+	var lastErr error
 	for i := 1; i <= maxTries; i++ {
-		if err := psqlDb.Ping(); err != nil {
-			time.Sleep(1 * time.Second)
-			log.Err(err).Msgf("error pinging database, attempt: %d", i)
-		} else {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		lastErr = psqlDb.PingContext(ctx)
+		cancel()
+		if lastErr == nil {
 			log.Info().Msg("database connection successful")
 			if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
 				psqlDb.SetMaxOpenConns(2)
@@ -35,7 +44,9 @@ func SetupPostgresDatabase() *sql.DB {
 			}
 			return psqlDb
 		}
+		log.Error().Err(lastErr).Msgf("error pinging database, attempt %d/%d", i, maxTries)
+		time.Sleep(1 * time.Second)
 	}
-	log.Fatal().Msgf("error pinging database, gave up after %d attempts", maxTries)
+	log.Fatal().Err(lastErr).Msgf("error pinging database, gave up after %d attempts", maxTries)
 	return nil
 }

--- a/bookings/internal/pkg/persistance/postgresql/setup.go
+++ b/bookings/internal/pkg/persistance/postgresql/setup.go
@@ -1,7 +1,9 @@
 package postgresql
 
 import (
+	"context"
 	"database/sql"
+	"net/url"
 	"os"
 	"time"
 
@@ -12,16 +14,23 @@ import (
 )
 
 func SetupPostgresDatabase() *sql.DB {
-	psqlDb, err := sql.Open("postgres", config.DatabaseUrl())
+	dbURL := config.DatabaseUrl()
+	if u, err := url.Parse(dbURL); err == nil {
+		log.Info().Str("host", u.Host).Str("db", u.Path).Msg("connecting to database")
+	}
+
+	psqlDb, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error opening database connection")
 	}
-	maxTries := 10
+
+	const maxTries = 10
+	var lastErr error
 	for i := 1; i <= maxTries; i++ {
-		if err := psqlDb.Ping(); err != nil {
-			time.Sleep(1 * time.Second)
-			log.Err(err).Msgf("error pinging database, attempt: %d", i)
-		} else {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		lastErr = psqlDb.PingContext(ctx)
+		cancel()
+		if lastErr == nil {
 			log.Info().Msg("database connection successful")
 			if os.Getenv("AWS_LAMBDA_FUNCTION_NAME") != "" {
 				psqlDb.SetMaxOpenConns(2)
@@ -36,7 +45,9 @@ func SetupPostgresDatabase() *sql.DB {
 			}
 			return psqlDb
 		}
+		log.Error().Err(lastErr).Msgf("error pinging database, attempt %d/%d", i, maxTries)
+		time.Sleep(1 * time.Second)
 	}
-	log.Fatal().Msgf("Error pinging database, gave up after %d attempts", maxTries)
+	log.Fatal().Err(lastErr).Msgf("error pinging database, gave up after %d attempts", maxTries)
 	return nil
 }

--- a/infrastructure/production/terraform/modules/iam/main.tf
+++ b/infrastructure/production/terraform/modules/iam/main.tf
@@ -220,6 +220,18 @@ resource "aws_iam_role_policy" "github_deploy" {
         Action   = ["lambda:InvokeFunction"]
         Resource = "arn:aws:lambda:${var.aws_region}:${var.aws_account}:function:${var.prefix}-*-migrate"
       },
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams",
+          "logs:FilterLogEvents",
+          "logs:GetLogEvents",
+          "logs:StartQuery",
+          "logs:GetQueryResults",
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${var.aws_account}:log-group:/aws/lambda/${var.prefix}-*:*"
+      },
     ]
   })
 }

--- a/journal/internal/pkg/persistance/postgres/setup.go
+++ b/journal/internal/pkg/persistance/postgres/setup.go
@@ -1,7 +1,9 @@
 package postgres
 
 import (
+	"context"
 	"database/sql"
+	"net/url"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -10,16 +12,23 @@ import (
 )
 
 func SetupPostgresDatabase() *sql.DB {
-	psqlDb, err := sql.Open("postgres", config.DatabaseUrl())
+	dbURL := config.DatabaseUrl()
+	if u, err := url.Parse(dbURL); err == nil {
+		log.Info().Str("host", u.Host).Str("db", u.Path).Msg("connecting to database")
+	}
+
+	psqlDb, err := sql.Open("postgres", dbURL)
 	if err != nil {
 		log.Fatal().Err(err).Msg("error opening database connection")
 	}
-	maxTries := 10
+
+	const maxTries = 10
+	var lastErr error
 	for i := 1; i <= maxTries; i++ {
-		if err := psqlDb.Ping(); err != nil {
-			time.Sleep(1 * time.Second)
-			log.Err(err).Msgf("error pinging database, attempt: %d", i)
-		} else {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		lastErr = psqlDb.PingContext(ctx)
+		cancel()
+		if lastErr == nil {
 			log.Info().Msg("database connection successful")
 			psqlDb.SetMaxOpenConns(5)
 			psqlDb.SetMaxIdleConns(5)
@@ -27,7 +36,9 @@ func SetupPostgresDatabase() *sql.DB {
 			psqlDb.SetConnMaxIdleTime(2 * time.Minute)
 			return psqlDb
 		}
+		log.Error().Err(lastErr).Msgf("error pinging database, attempt %d/%d", i, maxTries)
+		time.Sleep(1 * time.Second)
 	}
-	log.Fatal().Msgf("Error pinging database, gave up after %d attempts", maxTries)
+	log.Fatal().Err(lastErr).Msgf("error pinging database, gave up after %d attempts", maxTries)
 	return nil
 }


### PR DESCRIPTION
- Grant the GitHub deploy IAM role logs:FilterLogEvents,
  GetLogEvents, DescribeLogStreams/Groups, StartQuery, GetQueryResults
  on all bilcool-production Lambda log groups so CI can read logs.
- Add .github/workflows/fetch-logs.yml (workflow_dispatch) that
  fetches the last N hours of logs for any Lambda function and
  prints them to the job summary; supports an optional keyword filter.

Run "Fetch CloudWatch Logs" from GitHub Actions → select function
(e.g. authentication-http) and hours to see production log output.

https://claude.ai/code/session_013h95eVa83oVcrTyCecYXTE