### PR TITLE
Fix booking distance lost on logout mid-booking

### DIFF
--- a/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.test.tsx
+++ b/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import BookingStartEndDialog from './BookingStartEndDialog'
+import type { BookingResponse } from '../../types/api'
+
+vi.mock('../../api/bookings', () => ({
+  endBooking: vi.fn(),
+  deleteBooking: vi.fn(),
+  pauseBooking: vi.fn(),
+  resumeBooking: vi.fn(),
+  addTrackPoints: vi.fn(),
+}))
+
+const startedBooking: BookingResponse = {
+  user_ref: 'user-1',
+  booking_reference: 'booking-ref-1',
+  start_date: '2020-01-01T10:00:00Z',
+  end_date: '2020-01-01T18:00:00Z',
+}
+
+function renderDialog() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <BookingStartEndDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        booking={startedBooking}
+        hasDistance={false}
+      />
+    </QueryClientProvider>,
+  )
+}
+
+describe('BookingStartEndDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('submits the correct distance after the dialog is remounted following a logout', async () => {
+    const { endBooking } = await import('../../api/bookings')
+    vi.mocked(endBooking).mockResolvedValue(undefined)
+
+    // 1. user opens "end booking" and enters odometer readings
+    const first = renderDialog()
+    fireEvent.change(document.getElementById('start-odo') as HTMLInputElement, { target: { value: '100' } })
+    fireEvent.change(document.getElementById('end-odo') as HTMLInputElement, { target: { value: '150' } })
+
+    // 2. user is logged out mid-entry: RequireAuth redirects to /login,
+    // unmounting the dialog before they hit submit
+    first.unmount()
+
+    // 3. user logs back in and reopens the same booking
+    const second = renderDialog()
+    const form = document.getElementById('end-booking-form')!
+    fireEvent.submit(form)
+
+    // 4. the booking should end with the distance the user had already
+    // entered before being logged out - not lost, not re-typed
+    await waitFor(() => {
+      expect(endBooking).toHaveBeenCalledWith('booking-ref-1', {
+        odometer_start: 100000,
+        odometer_end: 150000,
+      })
+    })
+
+    second.unmount()
+  })
+})

--- a/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
+++ b/ui/bilcool-ui/src/components/bookings/BookingStartEndDialog.tsx
@@ -31,6 +31,30 @@ const endSchema = z
 
 type EndFormValues = z.infer<typeof endSchema>
 
+type OdoDraft = Partial<EndFormValues>
+
+function draftKey(bookingRef: string) {
+  return `booking-draft:${bookingRef}`
+}
+
+function readDraft(bookingRef: string): OdoDraft | undefined {
+  const raw = sessionStorage.getItem(draftKey(bookingRef))
+  if (!raw) return undefined
+  try {
+    return JSON.parse(raw) as OdoDraft
+  } catch {
+    return undefined
+  }
+}
+
+function writeDraft(bookingRef: string, draft: OdoDraft) {
+  sessionStorage.setItem(draftKey(bookingRef), JSON.stringify(draft))
+}
+
+function clearDraft(bookingRef: string) {
+  sessionStorage.removeItem(draftKey(bookingRef))
+}
+
 interface BookingStartEndDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -86,13 +110,28 @@ export default function BookingStartEndDialog({
   const {
     register,
     handleSubmit,
+    watch,
     formState: { errors, isSubmitting },
   } = useForm<EndFormValues>({
     resolver: zodResolver(endSchema),
+    defaultValues: readDraft(booking.booking_reference),
   })
+
+  useEffect(() => {
+    const subscription = watch((values) => {
+      const draft: OdoDraft = {}
+      if (Number.isFinite(values.startOdo)) draft.startOdo = values.startOdo
+      if (Number.isFinite(values.endOdo)) draft.endOdo = values.endOdo
+      if (draft.startOdo !== undefined || draft.endOdo !== undefined) {
+        writeDraft(booking.booking_reference, draft)
+      }
+    })
+    return () => subscription.unsubscribe()
+  }, [watch, booking.booking_reference])
 
   async function handleDelete() {
     await deleteBooking.mutateAsync(booking.booking_reference)
+    clearDraft(booking.booking_reference)
     onOpenChange(false)
   }
 
@@ -104,6 +143,7 @@ export default function BookingStartEndDialog({
         position: currentPosition ?? undefined,
       },
     })
+    clearDraft(booking.booking_reference)
     onOpenChange(false)
   }
 
@@ -130,6 +170,7 @@ export default function BookingStartEndDialog({
         odometer_end: data.endOdo * 1000,
       },
     })
+    clearDraft(booking.booking_reference)
     onOpenChange(false)
   }
 

--- a/ui/bilcool-ui/src/router.test.tsx
+++ b/ui/bilcool-ui/src/router.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { useEffect } from 'react'
+import { RequireAuth } from './router'
+import { useAuthStore } from './stores/authStore'
+
+function TrackedChild({ onUnmount }: { onUnmount: () => void }) {
+  useEffect(() => onUnmount, [onUnmount])
+  return <div>booking-in-progress</div>
+}
+
+function renderGuarded() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings']}>
+      <Routes>
+        <Route path="/login" element={<div>login</div>} />
+        <Route element={<RequireAuth />}>
+          <Route
+            path="/bookings"
+            element={<TrackedChild onUnmount={onUnmountSpy} />}
+          />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+let onUnmountSpy: () => void
+
+describe('RequireAuth', () => {
+  afterEach(() => {
+    cleanup()
+    useAuthStore.getState().clearAuth()
+  })
+
+  it('unmounts the in-progress booking flow when the user is logged out', () => {
+    useAuthStore.setState({ isAuthenticated: true })
+    onUnmountSpy = vi.fn()
+
+    const { rerender } = renderGuarded()
+    expect(onUnmountSpy).not.toHaveBeenCalled()
+
+    // simulate a logout occurring mid-booking (explicit logout, or an
+    // expired-token check clearing auth state)
+    useAuthStore.getState().clearAuth()
+    rerender(
+      <MemoryRouter initialEntries={['/bookings']}>
+        <Routes>
+          <Route path="/login" element={<div>login</div>} />
+          <Route element={<RequireAuth />}>
+            <Route
+              path="/bookings"
+              element={<TrackedChild onUnmount={onUnmountSpy} />}
+            />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(onUnmountSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/bilcool-ui/src/router.tsx
+++ b/ui/bilcool-ui/src/router.tsx
@@ -10,7 +10,7 @@ import AdminUsersPage from './pages/AdminUsersPage'
 import WhereIsPage from './pages/WhereIsPage'
 import NotFoundPage from './pages/NotFoundPage'
 
-function RequireAuth() {
+export function RequireAuth() {
   const isAuthenticated = useAuthStore((s) => s.isAuthenticated)
   if (!isAuthenticated) return <Navigate to="/login" replace />
   return <Outlet />


### PR DESCRIPTION
## Summary
- Root cause: `RequireAuth` (`ui/bilcool-ui/src/router.tsx`) redirects to `/login` and unmounts the routed subtree whenever the user is logged out. `BookingStartEndDialog`'s odometer form only ever lived in in-memory `react-hook-form` state, so a logout mid-entry wiped whatever the user had typed, with no way to recover the trip's distance.
- Fix: persist the in-progress odometer draft to `sessionStorage`, scoped by `booking_reference`, and restore it when the dialog mounts again for the same booking. The draft is cleared once the booking is successfully ended (via odometer or GPS), or deleted.
- Added `router.test.tsx` to pin down the unmount-on-logout mechanism itself (exported `RequireAuth` for testability).
- Added `BookingStartEndDialog.test.tsx`, which fails before the fix (remounted dialog submits with lost/empty odometer values) and passes after (draft is restored and submitted with the originally entered distance).

## Test plan
- [x] `npm test` (vitest) — all 8 test files / 40 tests pass, including the two new ones
- [x] `npx tsc -b --noEmit` — no type errors
- [x] `npm run lint` — no new lint errors introduced (verified against the base branch)


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2yX6PSdCNMVNxR9AWMgQL)_